### PR TITLE
Switchable Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,14 @@ The chart provides some annotation to handle the prediction and watch strike eve
 On each (x, y) points Its present a tooltip that show points, date time and reason of points gained / lost. This web page was just a funny idea, and it is not intended to use for a professional usage.
 If you want you can toggle the dark theme with the dedicated checkbox.
 
+### `enableAnalytics.py` file in the main directory toggles Analytics
+Disabling Analytics significantly reduces memory consumption and saves some disk space.
+
+- Remove this file if you don't need Analytics. Or rename it to something different, like `disableAnalytics.py`.
+- To enable Analytics back - just create this file again. Or rename it back to `enableAnalytics.py`.
+
+This file can be empty.
+
 | Light theme | Dark theme |
 | ----------- | ---------- |
 | ![Light theme](https://raw.githubusercontent.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/master/assets/chart-analytics-light.png) | ![Dark theme](https://raw.githubusercontent.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/master/assets/chart-analytics-dark.png) |

--- a/TwitchChannelPointsMiner/logger.py
+++ b/TwitchChannelPointsMiner/logger.py
@@ -68,7 +68,7 @@ class LoggerSettings:
         "color_palette",
         "auto_clear",
         "telegram",
-        "discord",
+        "discord"
     ]
 
     def __init__(

--- a/enableAnalytics.py
+++ b/enableAnalytics.py
@@ -1,0 +1,4 @@
+# Significantly reduces memory consumption and saves some disk space.
+# Remove this file if you don't need Analytics. Or rename it to something different, like "disableAnalytics.py".
+# To enable Analytics back - just create this file again. Or rename it back to "enableAnalytics.py".
+# This file can be empty.


### PR DESCRIPTION
# Description

### `enableAnalytics.py` file in the main directory toggles Analytics

Disabling Analytics significantly reduces memory consumption and saves some disk space by not creating and writing `/analytics/*.json`.

- Remove this file if you don't need Analytics. Or rename it to something different, like disableAnalytics.py.
- To enable Analytics back - just create this file again. Or rename it back to enableAnalytics.py.

This file can be empty.

Fixes # [(issue)](https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/issues/2)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

From tests that I've done on my Windows 10 PC - it reduces memory consumption significantly - from **800 MB** with analytics enabled to **40 MB** with disabled. On my Linux boxes it also becomes less memory-hungry.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
