### PR TITLE
console_username in logger_settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ twitch_miner = TwitchChannelPointsMiner(
     logger_settings=LoggerSettings(
         save=True,                              # If you want to save logs in a file (suggested)
         console_level=logging.INFO,             # Level of logs - use logging.DEBUG for more info
+        console_username=False,                 # Adds a username to every console log line if True. Useful when you have many open consoles with different accounts
         file_level=logging.DEBUG,               # Level of logs - If you think the log file it's too big, use logging.INFO
         emoji=True,                             # On Windows, we have a problem printing emoji. Set to false if you have a problem
         less=False,                             # If you think that the logs are too verbose, set this to True
@@ -414,6 +415,7 @@ You can combine all priority but keep in mind that use `ORDER` and `POINTS_ASCEN
 | `save`           | bool             | True                                                              | If you want to save logs in file (suggested)                                                                                                                                            |
 | `less`           | bool             | False                                                             | Reduce the logging format and message verbosity [#10](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/10)                                                               |
 | `console_level`  | level          | logging.INFO                                                      | Level of logs in terminal - Use logging.DEBUG for more helpful messages.                                                                                                                |
+| `console_username`  | bool          | False                                                      | Adds a username to every log line in the console if True. [#602](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/602)                                                                                                                |
 | `file_level`     | level          | logging.DEBUG                                                     | Level of logs in file save - If you think the log file it's too big, use logging.INFO                                                                                                    |
 | `emoji`          | bool             | For Windows is False else True                                    | On Windows, we have a problem printing emoji. Set to false if you have a problem                                                                                                         |
 | `colored`         | bool             | True                                                                | If you want to print colored text [#45](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/45) [#82](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/82) |

--- a/TwitchChannelPointsMiner/logger.py
+++ b/TwitchChannelPointsMiner/logger.py
@@ -62,6 +62,7 @@ class LoggerSettings:
         "save",
         "less",
         "console_level",
+        "console_username",
         "file_level",
         "emoji",
         "colored",
@@ -76,6 +77,7 @@ class LoggerSettings:
         save: bool = True,
         less: bool = False,
         console_level: int = logging.INFO,
+        console_username: bool = False,
         file_level: int = logging.DEBUG,
         emoji: bool = platform.system() != "Windows",
         colored: bool = False,
@@ -87,6 +89,7 @@ class LoggerSettings:
         self.save = save
         self.less = less
         self.console_level = console_level
+        self.console_username = console_username
         self.file_level = file_level
         self.emoji = emoji
         self.colored = colored
@@ -169,14 +172,17 @@ def configure_loggers(username, settings):
     # Send log messages to another thread through the queue
     root_logger.addHandler(queue_handler)
 
+    # Adding a username to the format based on settings
+    console_username = "" if settings.console_username is False else f"[{username}] "
+
     console_handler = logging.StreamHandler()
     console_handler.setLevel(settings.console_level)
     console_handler.setFormatter(
         GlobalFormatter(
             fmt=(
-                "%(asctime)s - %(levelname)s - [%(funcName)s]: %(message)s"
+                "%(asctime)s - %(levelname)s - [%(funcName)s]: " + console_username + "%(message)s"
                 if settings.less is False
-                else "%(asctime)s - %(message)s"
+                else "%(asctime)s - " + console_username + "%(message)s"
             ),
             datefmt=(
                 "%d/%m/%y %H:%M:%S" if settings.less is False else "%d/%m %H:%M:%S"

--- a/example.py
+++ b/example.py
@@ -23,6 +23,7 @@ twitch_miner = TwitchChannelPointsMiner(
     logger_settings=LoggerSettings(
         save=True,                              # If you want to save logs in a file (suggested)
         console_level=logging.INFO,             # Level of logs - use logging.DEBUG for more info
+        console_username=False,                 # Adds a username to every console log line if True. Useful when you have many open consoles with different accounts
         file_level=logging.DEBUG,               # Level of logs - If you think the log file it's too big, use logging.INFO
         emoji=True,                             # On Windows, we have a problem printing emoji. Set to false if you have a problem
         less=False,                             # If you think that the logs are too verbose, set this to True


### PR DESCRIPTION
# Description

`console_username` option in `logger_settings` adds a username to every log line in the console if True.

Fixes [#602](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/602)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on the old config - works as expected, if no such option - defaults to `False`.
No breaking changes has been made.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
