### PR TITLE
temporary login fix (only by browser cookie)

### DIFF
--- a/TwitchChannelPointsMiner/__init__.py
+++ b/TwitchChannelPointsMiner/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = "1.3.4"
+__version__ = "1.3.5"
 from .TwitchChannelPointsMiner import TwitchChannelPointsMiner
 
 __all__ = [

--- a/TwitchChannelPointsMiner/classes/TwitchLogin.py
+++ b/TwitchChannelPointsMiner/classes/TwitchLogin.py
@@ -57,8 +57,9 @@ class TwitchLogin(object):
             "undelete_user": False,
             "remember_me": True,
         }
-
-        use_backup_flow = False
+        # login-fix
+        #use_backup_flow = False
+        use_backup_flow = True
 
         for attempt in range(0, 25):
             password = (
@@ -118,7 +119,9 @@ class TwitchLogin(object):
 
                         # If the user didn't load the password from run.py we can just ask for it again.
                         break
-                    elif err_code == 1000:
+                    # login-fix
+                    #elif err_code == 1000:
+                    elif err_code in [1000, 5022]:
                         logger.info(
                             "Console login unavailable (CAPTCHA solving required)."
                         )
@@ -148,7 +151,7 @@ class TwitchLogin(object):
         self.session.headers.update({"Authorization": f"Bearer {self.token}"})
 
     def send_login_request(self, json_data):
-        response = self.session.post("https://passport.twitch.tv/login", json=json_data)
+        response = self.session.post("https://passport.twitch.tv/protected_login", json=json_data)
         return response.json()
 
     def login_flow_backup(self):

--- a/TwitchChannelPointsMiner/constants.py
+++ b/TwitchChannelPointsMiner/constants.py
@@ -3,7 +3,8 @@ URL = "https://www.twitch.tv"
 IRC = "irc.chat.twitch.tv"
 IRC_PORT = 6667
 WEBSOCKET = "wss://pubsub-edge.twitch.tv/v1"
-CLIENT_ID = "kd1unb4b3q4t58fwlpcbzcbnm76a8fp"
+CLIENT_ID = "kd1unb4b3q4t58fwlpcbzcbnm76a8fp" # Android App
+#CLIENT_ID = "851cqzxpb9bqu9z6galo155du" # iOS App
 DROP_ID = "c2542d6d-cd10-4532-919b-3d19f30a768b"
 CLIENT_VERSION = "32d439b2-bd5b-4e35-b82a-fae10b04da70"
 


### PR DESCRIPTION
# Description

Twitch made severe changes to the login procedure, so I had to do this temporary fix. Console login no longer works if you don't have a saved cookie (`cookies/<USERNAME>.pkl`).

For now, you can only login via the browser cookie for the first time.

Unfortunately, bonus claiming, etc will not work with this new cookie. We need to figure out a way to fix it. If you have any suggestions - welcome to https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/issues/15.