### PR TITLE
Add release tag on docker image

### DIFF
--- a/.github/workflows/deploy-release-docker.yml
+++ b/.github/workflows/deploy-release-docker.yml
@@ -1,0 +1,52 @@
+name: deploy-release-docker
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+  workflow_dispatch:
+
+jobs:
+  deploy-docker:
+    name: Deploy Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.2.1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push AMD64, ARM64, ARMv7
+        id: docker_build
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: .
+          push: true
+          tags: |
+            rdavidoff/twitch-channel-points-miner-v2:$RELEASE_VERSION
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          build-args: BUILDX_QEMU_ENV=true
+
+      # File size exceeds the maximum allowed 25000 bytes
+      # - name: Docker Hub Description
+      #   uses: peter-evans/dockerhub-description@v2
+      #   with:
+      #     username: ${{ secrets.DOCKER_USERNAME }}
+      #     password: ${{ secrets.DOCKER_TOKEN }}
+      #     repository: rdavidoff/twitch-channel-points-miner-v2
+
+      - name: Image digest AMD64, ARM64, ARMv7
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Add history version for docker image.
this new pipeline will only run when new tag is pushed and will build docker image with git tag value as its tag.

