### PR TITLE
Fix EventPrediction on refund

### DIFF
--- a/TwitchChannelPointsMiner/classes/entities/EventPrediction.py
+++ b/TwitchChannelPointsMiner/classes/entities/EventPrediction.py
@@ -66,7 +66,9 @@ class EventPrediction(object):
         result_type = result["type"]
 
         points = {}
-        points["placed"] = self.bet.decision["amount"]
+        points["placed"] = (
+            self.bet.decision["amount"] if result_type != "REFUND" else 0
+        )
         points["won"] = (
             result["points_won"]
             if result["points_won"] or result_type == "REFUND"


### PR DESCRIPTION
# Description

12/02/23 13:39:08 - INFO - [on_message]: +2000 --> Streamer(username=xxxxxxxx, channel_id=xxxxxxxx, channel_points=2.62k) - Reason: REFUND. 12/02/23 13:39:08 - ERROR - [on_message]: Exception raised for topic: predictions-user-v1 and message:  {
   "type":"prediction-result",
   "data":{
      "timestamp":"2023-02-12T12:41:45.371055608Z",
      "prediction":{
         "id":"xxxxxxxxxx",
         "event_id":"xxxxxxxxxx",
         "outcome_id":"xxxxxxxxxx",
         "channel_id":"xxxxxxxx",
         "points":2000,
         "predicted_at":"2023-02-12T12:41:28.150531011Z",
         "updated_at":"2023-02-12T12:41:45.365963188Z",
         "user_id":"xxxxxxxx",
         "result":{
            "type":"REFUND",
            "points_won":"None",
            "is_acknowledged":false
         },
         "user_display_name":"None"
      }
   }
}
Traceback (most recent call last):
  File "\TwitchChannelPointsMiner\classes\WebSocketsPool.py", line 325, in on_message
    points = event_prediction.parse_result(
  File "\TwitchChannelPointsMiner\classes\entities\EventPrediction.py", line 69, in parse_result
    points["placed"] = self.bet.decision["amount"]
KeyError: 'amount'


# Fixes 
KeyError on undefined key EventPrediction.py#69


