### PR TITLE
fix: rdavydov/Twitch-Channel-Points-Miner-v2#251

### DIFF
--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -801,12 +801,15 @@ class Twitch(object):
 
                     # Going to clear array and structure. Remove all the timeBasedDrops expired or not started yet
                     for index in range(0, len(campaigns_details)):
-                        campaign = Campaign(campaigns_details[index])
-                        if campaign.dt_match is True:
-                            # Remove all the drops already claimed or with dt not matching
-                            campaign.clear_drops()
-                            if campaign.drops != []:
-                                campaigns.append(campaign)
+                        if campaigns_details[index] is not None:
+                            campaign = Campaign(campaigns_details[index])
+                            if campaign.dt_match is True:
+                                # Remove all the drops already claimed or with dt not matching
+                                campaign.clear_drops()
+                                if campaign.drops != []:
+                                    campaigns.append(campaign)
+                        else:
+                            continue
 
                 # Divide et impera :)
                 campaigns = self.__sync_campaigns(campaigns)


### PR DESCRIPTION
Fixes #251 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Description

Addressing TypeError that occurs in the sync_campaigns function when a None object is passed to the Campaign class constructor. The error message states "'NoneType' object is not subscriptable," which means that a None object was accessed as if it were a dictionary.

To fix the issue, I've added a check to ensure that the campaigns_details[index] object is not None before passing it to the Campaign class constructor. If it is None, the loop will skip the current iteration, preventing the TypeError from occurring. The modified code block looks like this:

```py
for index in range(0, len(campaigns_details)):
    if campaigns_details[index] is not None:
        campaign = Campaign(campaigns_details[index])
        if campaign.dt_match is True:
            campaign.clear_drops()
            if campaign.drops != []:
                campaigns.append(campaign)
    else:
        continue
```

Basically just making sure when `campaigns_details[index]` is None it just continues and doesn't post error to console