### PR TITLE
Fix infinite loading if streamer hasn't been streaming

### DIFF
--- a/TwitchChannelPointsMiner/classes/AnalyticsServer.py
+++ b/TwitchChannelPointsMiner/classes/AnalyticsServer.py
@@ -51,6 +51,8 @@ def filter_datas(start_date, end_date, datas):
         else datetime.now()
     ).replace(hour=23, minute=59, second=59).timestamp() * 1000
 
+    original_series = datas["series"]
+    
     if "series" in datas:
         df = pd.DataFrame(datas["series"])
         df["datetime"] = pd.to_datetime(df.x // 1000, unit="s")
@@ -66,6 +68,20 @@ def filter_datas(start_date, end_date, datas):
     else:
         datas["series"] = []
 
+    # If no data is found within the timeframe, that usually means the streamer hasn't streamed within that timeframe
+    # We create a series that shows up as a straight line on the dashboard, with 'No Stream' as labels 
+    if len(datas["series"]) == 0: 
+        new_end_date = start_date; 
+        new_start_date = 0; 
+        df = pd.DataFrame(original_series)
+        df["datetime"] = pd.to_datetime(df.x // 1000, unit="s")
+
+        # Attempt to get the last known balance from before the provided timeframe
+        df = df[(df.x >= new_start_date) & (df.x <= new_end_date)]
+        last_balance = df.drop(columns="datetime").sort_values(by=["x", "y"], ascending=True).to_dict("records")[-1]['y'] 
+
+        datas["series"] = [{'x': start_date, 'y': last_balance, 'z': 'No Stream'}, {'x': end_date, 'y': last_balance, 'z': 'No Stream'}]; 
+        
     if "annotations" in datas:
         df = pd.DataFrame(datas["annotations"])
         df["datetime"] = pd.to_datetime(df.x // 1000, unit="s")


### PR DESCRIPTION
Current behavior for the Analytics dashboard when a streamer hasn't gone live within the selected timeframe is an infinitely loading graph. To fix this, I propose the following change which will instead try to fetch the last known point balance and display a straight line as the graph.
Streamers that have not gone live or for who you have not gained any points in the selected timeframe will now show up as follows (given there is data available from before the time frame)
![image](https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/assets/84308084/11cc7d29-a0ab-40bb-9af4-4c9f95e6524a)
As opposed to the infinite loading:
![image](https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/assets/84308084/f07f9f08-896e-4f90-9a26-57de75dfe107)

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
By attempting to view statistics for several streamers who have not gone live in the past month via the Analytics pageI've verified that normal behavior is not affected, and the bug is fixed. Streamers who have gone live recently still show up as normal, streamers for who there is data in the analytics/*.json file from before the timeframe no longer load infinitely and points are displayed as a straight line for them. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt

Fixes: #270 
