### PR TITLE
Fix for PubSub reconnection bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-added-large-files
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     -   id: isort
         files: ^TwitchChannelPointsMiner/
@@ -16,7 +16,7 @@ repos:
     hooks:
     -   id: black
         files: ^TwitchChannelPointsMiner/
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     -   id: flake8

--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -88,8 +88,7 @@ class TwitchChannelPointsMiner:
     ):
         # Fixes TypeError: 'NoneType' object is not subscriptable
         if not username or username == "your-twitch-username":
-            logger.error(
-                "Please edit your runner file (usually run.py) and try again.")
+            logger.error("Please edit your runner file (usually run.py) and try again.")
             logger.error("No username, exiting...")
             sys.exit(0)
 
@@ -122,7 +121,8 @@ class TwitchChannelPointsMiner:
 
         if enable_analytics is True:
             Settings.analytics_path = os.path.join(
-                Path().absolute(), "analytics", username)
+                Path().absolute(), "analytics", username
+            )
             Path(Settings.analytics_path).mkdir(parents=True, exist_ok=True)
 
         self.username = username
@@ -161,17 +161,16 @@ class TwitchChannelPointsMiner:
         current_version, github_version = check_versions()
 
         logger.info(
-            f"Twitch Channel Points Miner v2-{current_version} (fork by rdavydov)")
-        logger.info(
-            "https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2")
+            f"Twitch Channel Points Miner v2-{current_version} (fork by rdavydov)"
+        )
+        logger.info("https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2")
 
         if github_version == "0.0.0":
             logger.error(
                 "Unable to detect if you have the latest version of this script"
             )
         elif current_version != github_version:
-            logger.info(
-                f"You are running the version {current_version} of this script")
+            logger.info(f"You are running the version {current_version} of this script")
             logger.info(f"The latest version on GitHub is: {github_version}")
 
         for sign in [signal.SIGINT, signal.SIGSEGV, signal.SIGTERM]:
@@ -195,8 +194,7 @@ class TwitchChannelPointsMiner:
             http_server.name = "Analytics Thread"
             http_server.start()
         else:
-            logger.error(
-                "Can't start analytics(), please set enable_analytics=True")
+            logger.error("Can't start analytics(), please set enable_analytics=True")
 
     def mine(
         self,
@@ -242,8 +240,7 @@ class TwitchChannelPointsMiner:
                     streamers_dict[username] = streamer
 
             if followers is True:
-                followers_array = self.twitch.get_followers(
-                    order=followers_order)
+                followers_array = self.twitch.get_followers(order=followers_order)
                 logger.info(
                     f"Load {len(followers_array)} followers from your profile!",
                     extra={"emoji": ":clipboard:"},
@@ -266,8 +263,7 @@ class TwitchChannelPointsMiner:
                             if isinstance(streamers_dict[username], Streamer) is True
                             else Streamer(username)
                         )
-                        streamer.channel_id = self.twitch.get_channel_id(
-                            username)
+                        streamer.channel_id = self.twitch.get_channel_id(username)
                         streamer.settings = set_default_settings(
                             streamer.settings, Settings.streamer_settings
                         )
@@ -309,8 +305,7 @@ class TwitchChannelPointsMiner:
             # If we have at least one streamer with settings = claim_drops True
             # Spawn a thread for sync inventory and dashboard
             if (
-                at_least_one_value_in_settings_is(
-                    self.streamers, "claim_drops", True)
+                at_least_one_value_in_settings_is(self.streamers, "claim_drops", True)
                 is True
             ):
                 self.sync_campaigns_thread = threading.Thread(
@@ -369,14 +364,12 @@ class TwitchChannelPointsMiner:
 
                 if streamer.settings.make_predictions is True:
                     self.ws_pool.submit(
-                        PubsubTopic("predictions-channel-v1",
-                                    streamer=streamer)
+                        PubsubTopic("predictions-channel-v1", streamer=streamer)
                     )
 
                 if streamer.settings.claim_moments is True:
                     self.ws_pool.submit(
-                        PubsubTopic("community-moments-channel-v1",
-                                    streamer=streamer)
+                        PubsubTopic("community-moments-channel-v1", streamer=streamer)
                     )
 
             refresh_context = time.time()
@@ -386,15 +379,14 @@ class TwitchChannelPointsMiner:
                 # Check if is not None because maybe we have already created a new connection on array+1 and now index is None
                 for index in range(0, len(self.ws_pool.ws)):
                     if (
-                        self.ws_pool.ws[index].is_reconneting is False
+                        self.ws_pool.ws[index].is_reconnecting is False
                         and self.ws_pool.ws[index].elapsed_last_ping() > 10
                         and internet_connection_available() is True
                     ):
                         logger.info(
                             f"#{index} - The last PING was sent more than 10 minutes ago. Reconnecting to the WebSocket..."
                         )
-                        WebSocketsPool.handle_reconnection(
-                            self.ws_pool.ws[index])
+                        WebSocketsPool.handle_reconnection(self.ws_pool.ws[index])
 
                 if ((time.time() - refresh_context) // 60) >= 30:
                     refresh_context = time.time()

--- a/TwitchChannelPointsMiner/classes/TwitchWebSocket.py
+++ b/TwitchChannelPointsMiner/classes/TwitchWebSocket.py
@@ -18,7 +18,7 @@ class TwitchWebSocket(WebSocketApp):
         self.is_closed = False
         self.is_opened = False
 
-        self.is_reconneting = False
+        self.is_reconnecting = False
         self.forced_close = False
 
         # Custom attribute

--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -52,8 +52,7 @@ class WebSocketsPool:
         if self.ws[index].is_opened is False:
             self.ws[index].pending_topics.append(topic)
         else:
-            self.ws[index].listen(
-                topic, self.twitch.twitch_login.get_auth_token())
+            self.ws[index].listen(topic, self.twitch.twitch_login.get_auth_token())
 
     def __new(self, index):
         return TwitchWebSocket(
@@ -70,8 +69,12 @@ class WebSocketsPool:
     def __start(self, index):
         if Settings.disable_ssl_cert_verification is True:
             import ssl
-            thread_ws = Thread(target=lambda: self.ws[index].run_forever(
-                sslopt={"cert_reqs": ssl.CERT_NONE}))
+
+            thread_ws = Thread(
+                target=lambda: self.ws[index].run_forever(
+                    sslopt={"cert_reqs": ssl.CERT_NONE}
+                )
+            )
             logger.warn("SSL certificate verification is disabled! Be aware!")
         else:
             thread_ws = Thread(target=lambda: self.ws[index].run_forever())
@@ -96,7 +99,7 @@ class WebSocketsPool:
             while ws.is_closed is False:
                 # Else: the ws is currently in reconnecting phase, you can't do ping or other operation.
                 # Probably this ws will be closed very soon with ws.is_closed = True
-                if ws.is_reconneting is False:
+                if ws.is_reconnecting is False:
                     ws.ping()  # We need ping for keep the connection alive
                     time.sleep(random.uniform(25, 30))
 
@@ -124,38 +127,40 @@ class WebSocketsPool:
 
     @staticmethod
     def handle_reconnection(ws):
-        # Close the current WebSocket.
-        ws.is_closed = True
-        ws.keep_running = False
-        # Reconnect only if ws.forced_close is False (replace the keep_running)
+        # Reconnect only if ws.is_reconnecting is False to prevent more than 1 ws from being created
+        if ws.is_reconnecting is False:
+            # Close the current WebSocket.
+            ws.is_closed = True
+            ws.keep_running = False
+            # Reconnect only if ws.forced_close is False (replace the keep_running)
 
-        # Set the current socket as reconnecting status
-        # So the external ping check will be locked
-        ws.is_reconneting = True
+            # Set the current socket as reconnecting status
+            # So the external ping check will be locked
+            ws.is_reconnecting = True
 
-        if ws.forced_close is False:
-            logger.info(
-                f"#{ws.index} - Reconnecting to Twitch PubSub server in ~60 seconds"
-            )
-            time.sleep(30)
-
-            while internet_connection_available() is False:
-                random_sleep = random.randint(1, 3)
-                logger.warning(
-                    f"#{ws.index} - No internet connection available! Retry after {random_sleep}m"
+            if ws.forced_close is False:
+                logger.info(
+                    f"#{ws.index} - Reconnecting to Twitch PubSub server in ~60 seconds"
                 )
-                time.sleep(random_sleep * 60)
+                time.sleep(30)
 
-            # Why not create a new ws on the same array index? Let's try.
-            self = ws.parent_pool
-            # Create a new connection.
-            self.ws[ws.index] = self.__new(ws.index)
+                while internet_connection_available() is False:
+                    random_sleep = random.randint(1, 3)
+                    logger.warning(
+                        f"#{ws.index} - No internet connection available! Retry after {random_sleep}m"
+                    )
+                    time.sleep(random_sleep * 60)
 
-            self.__start(ws.index)  # Start a new thread.
-            time.sleep(30)
+                # Why not create a new ws on the same array index? Let's try.
+                self = ws.parent_pool
+                # Create a new connection.
+                self.ws[ws.index] = self.__new(ws.index)
 
-            for topic in ws.topics:
-                self.__submit(ws.index, topic)
+                self.__start(ws.index)  # Start a new thread.
+                time.sleep(30)
+
+                for topic in ws.topics:
+                    self.__submit(ws.index, topic)
 
     @staticmethod
     def on_message(ws, message):
@@ -179,8 +184,7 @@ class WebSocketsPool:
             ws.last_message_timestamp = message.timestamp
             ws.last_message_type_channel = message.identifier
 
-            streamer_index = get_streamer_index(
-                ws.streamers, message.channel_id)
+            streamer_index = get_streamer_index(ws.streamers, message.channel_id)
             if streamer_index != -1:
                 try:
                     if message.topic == "community-points-user-v1":
@@ -239,14 +243,12 @@ class WebSocketsPool:
                                 message.message["raid"]["id"],
                                 message.message["raid"]["target_login"],
                             )
-                            ws.twitch.update_raid(
-                                ws.streamers[streamer_index], raid)
+                            ws.twitch.update_raid(ws.streamers[streamer_index], raid)
 
                     elif message.topic == "community-moments-channel-v1":
                         if message.type == "active":
                             ws.twitch.claim_moment(
-                                ws.streamers[streamer_index],
-                                message.data["moment_id"]
+                                ws.streamers[streamer_index], message.data["moment_id"]
                             )
 
                     elif message.topic == "predictions-channel-v1":
@@ -381,7 +383,9 @@ class WebSocketsPool:
                                 if event_prediction.result["type"] != "LOSE":
                                     # Analytics switch
                                     if Settings.enable_analytics is True:
-                                        ws.streamers[streamer_index].persistent_annotations(
+                                        ws.streamers[
+                                            streamer_index
+                                        ].persistent_annotations(
                                             event_prediction.result["type"],
                                             f"{ws.events_predictions[event_id].title}",
                                         )
@@ -400,8 +404,7 @@ class WebSocketsPool:
                     )
 
         elif response["type"] == "RESPONSE" and len(response.get("error", "")) > 0:
-            raise RuntimeError(
-                f"Error while trying to listen for a topic: {response}")
+            raise RuntimeError(f"Error while trying to listen for a topic: {response}")
 
         elif response["type"] == "RECONNECT":
             logger.info(f"#{ws.index} - Reconnection required")


### PR DESCRIPTION
# Description

A fix for a bug that occurred during the response to a PubSub server `RECONNECT` message. In essence, a single WebSocket connection object spawned 2 new WebSockets both with the same pool index. My understanding is that there should only ever be a single WebSocket for each index in the pool and that reconnection should only produce a single new WebSocket.

I've also updated the `pre-commit` script with a new version of `isort` and changed the `flake8` repo to GitHub.

### INFO Logs
```
14/07/23 18:49:42 - INFO - [on_message]: #0 - Reconnection required
14/07/23 18:49:42 - INFO - [handle_reconnection]: #0 - Reconnecting to Twitch PubSub server in ~60 seconds
14/07/23 18:50:42 - INFO - [on_close]: #0 - WebSocket closed
14/07/23 18:50:42 - INFO - [handle_reconnection]: #0 - Reconnecting to Twitch PubSub server in ~60 seconds
14/07/23 18:54:28 - INFO - [on_message]: 🚀  +10 → Streamer(***) - Reason: WATCH.
14/07/23 18:54:28 - INFO - [claim_bonus]: 🎁  Claiming the bonus for Streamer(***)!
14/07/23 18:54:28 - INFO - [on_message]: 🚀  +10 → Streamer(***) - Reason: WATCH.
14/07/23 18:54:28 - INFO - [claim_bonus]: 🎁  Claiming the bonus for Streamer(***)!
```

### DEBUG Logs
```
14/07/23 18:54:28 - DEBUG - TwitchChannelPointsMiner.classes.WebSocketsPool - [on_message]: #0 - Received: {"type":"MESSAGE","data":{"topic":"community-points-user-v1.***","message":"{\"type\":\"points-earned\",\"data\":***}}}
14/07/23 18:54:28 - INFO - TwitchChannelPointsMiner.classes.WebSocketsPool - [on_message]: +10 → Streamer(***) - Reason: WATCH.
14/07/23 18:54:28 - DEBUG - TwitchChannelPointsMiner.classes.WebSocketsPool - [on_message]: #0 - Received: {"type":"MESSAGE","data":{"topic":"community-points-user-v1.***","message":"{\"type\":\"claim-available\",\"data\":***}}}
14/07/23 18:54:28 - INFO - TwitchChannelPointsMiner.classes.Twitch - [claim_bonus]: Claiming the bonus for Streamer(***)!
14/07/23 18:54:28 - DEBUG - urllib3.connectionpool - [_new_conn]: Starting new HTTPS connection (1): www.twitch.tv:443
14/07/23 18:54:28 - DEBUG - TwitchChannelPointsMiner.classes.WebSocketsPool - [on_message]: #0 - Received: { "type": "PONG" }
14/07/23 18:54:28 - DEBUG - TwitchChannelPointsMiner.classes.WebSocketsPool - [on_message]: #0 - Received: {"type":"MESSAGE","data":{"topic":"community-points-user-v1.***","message":"{\"type\":\"points-earned\",\"data\":***}}}
14/07/23 18:54:28 - INFO - TwitchChannelPointsMiner.classes.WebSocketsPool - [on_message]: +10 → Streamer(***) - Reason: WATCH.
14/07/23 18:54:28 - DEBUG - TwitchChannelPointsMiner.classes.WebSocketsPool - [on_message]: #0 - Received: {"type":"MESSAGE","data":{"topic":"community-points-user-v1.***","message":"{\"type\":\"claim-available\",\"data\":***}}}
14/07/23 18:54:28 - INFO - TwitchChannelPointsMiner.classes.Twitch - [claim_bonus]: Claiming the bonus for Streamer(***)!
```

I was monitoring the info logs for a local docker image and noticed that, after a PubSub `RECONNECT` message was finished being handled, I was getting 2 logs for each PubSub message. You can see this in the logs above, at 18:54:28 there are 2 logs for each `on_message` and `claim_bonus`, and though I've redacted the info they are for the same channel.  Looking through the debug logs I could see that I was also getting 2 corresponding `points_earned` and `claim_available` PubSub messages each. Additionally, from this point forward, the logs always showed these messages happening in pairs.

After reviewing the code paths I could see the issue was caused by `on_close` being called during the `handle_reconnection` flow. This causes an additional call to `handle_reconnection` and the flow gets run fully again, causing an additional WebSocket to be created and, since they're created on the same index, detaching the 1st new WebSocket from the pool's list. The result is that you end up with 1 new WebSocket in the pool and another new one detached from the pool, but both are operational.

Also, regarding `pre-commit`, I noticed when making a local commit that the hook failed to run. Turns out some of the packages were outdated so I've fixed that as part of the commit.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It's kind of difficult to test because it relies on these 2 events happening in quick succession, however, I'm confident this is the cause of the issue. If this issue hasn't come up before, that's probably because it's pretty rare for the server to send a `RECONNECT` (the docs suggest this happens typically for server maintenance) and even rarer still for `on_close` to get called in that 60 second window.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
