### PR TITLE
Add LOSE annotation to analytics page

### DIFF
--- a/TwitchChannelPointsMiner/classes/WebSocketsPool.py
+++ b/TwitchChannelPointsMiner/classes/WebSocketsPool.py
@@ -380,7 +380,7 @@ class WebSocketsPool:
                                         counter=-1,
                                     )
 
-                                if event_prediction.result["type"] != "LOSE":
+                                if event_prediction.result["type"]:
                                     # Analytics switch
                                     if Settings.enable_analytics is True:
                                         ws.streamers[

--- a/TwitchChannelPointsMiner/classes/entities/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/entities/Streamer.py
@@ -207,11 +207,11 @@ class Streamer(object):
     # === ANALYTICS === #
     def persistent_annotations(self, event_type, event_text):
         event_type = event_type.upper()
-        if event_type in ["WATCH_STREAK", "WIN", "PREDICTION_MADE"]:
+        if event_type in ["WATCH_STREAK", "WIN", "PREDICTION_MADE", "LOSE"]:
             primary_color = (
-                "#45c1ff"
+                "#45c1ff" #blue #45c1ff yellow #ffe045 green #36b535 red #ff4545 
                 if event_type == "WATCH_STREAK"
-                else ("#ffe045" if event_type == "PREDICTION_MADE" else "#54ff45")
+                else ("#ffe045" if event_type == "PREDICTION_MADE" else ("#36b535" if event_type == "WIN" else "#ff4545")) 
             )
             data = {
                 "borderColor": primary_color,


### PR DESCRIPTION
# Description

Add lose annotation to the analytics page and a new red color to distinguish from WINs
Previously, only WINs would show, resulting in no knowledge about losses.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Waited for the prediction result to be LOSE. 
![Red Annotation Example](https://i.imgur.com/GOP79UX.png)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (README.md)
- [X] My changes generate no new warnings
- [X] Any dependent changes have been updated in requirements.txt
