### PR TITLE
event-minute-watched update

### DIFF
--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -108,13 +108,17 @@ class Twitch(object):
                     "broadcast_id": streamer.stream.broadcast_id,
                     "player": "site",
                     "user_id": self.twitch_login.get_user_id(),
+                    "live": True,
+                    "channel": streamer.username
                 }
 
                 if (
                     streamer.stream.game_name() is not None
+                    and streamer.stream.game_id() is not None
                     and streamer.settings.claim_drops is True
                 ):
                     event_properties["game"] = streamer.stream.game_name()
+                    event_properties["game_id"] = streamer.stream.game_id()
                     # Update also the campaigns_ids so we are sure to tracking the correct campaign
                     streamer.stream.campaigns_ids = (
                         self.__get_campaign_ids_from_streamer(streamer)

--- a/TwitchChannelPointsMiner/classes/entities/Stream.py
+++ b/TwitchChannelPointsMiner/classes/entities/Stream.py
@@ -84,6 +84,9 @@ class Stream(object):
 
     def game_name(self):
         return None if self.game in [{}, None] else self.game["name"]
+    
+    def game_id(self):
+        return None if self.game in [{}, None] else self.game["id"]
 
     def update_required(self):
         return self.__last_update == 0 or self.update_elapsed() >= 120


### PR DESCRIPTION
Today, I'm running the Miner as usual. But I found that some living stream drops was not forward.

# Description

The official has changed some streamer live request. 
Some game live streams do not display the progress bar inside the upper-right corner avatar. Additionally, the previous minute watch events cannot successfully advance the progress.
Today, I found that minute-event-watched parameters required was more. so I add it.

![example_img](https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/assets/85232199/77febae0-ce99-4a8c-b29b-c1a3be1c7327)


## changes

- I have added a new method for the Stream entity.
- Additional parameters have been included for the minute-event-watched.

In my case, in the live streaming rooms of games Dead by Daylight and OW2, for example, three additional parameters are required. (live, channel, game_id)

## Test

The changes made this time have no impact on previous games, and progress can still proceed as usual

![image](https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/assets/85232199/41019772-2852-4cf8-b1be-5b0bf8c59999)
