### PR TITLE
Telegram message prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ twitch_miner = TwitchChannelPointsMiner(
             events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
                     Events.BET_LOSE, Events.CHAT_MENTION],                          # Only these events will be sent to the chat
             disable_notification=True,                                              # Revoke the notification (sound/vibration)
-            message_prefix="Essp "                                                  # Message prefix either False or a string (E.g. "User ") Useful when many miners using same messaging service. Add a space for formatting.
+            message_prefix=False                                                  # Message prefix either False or a string (E.g. "User ") Useful when many miners using same messaging service. Add a space for formatting.
         ),
         discord=Discord(
             webhook_api="https://discord.com/api/webhooks/0123456789/0a1B2c3D4e5F6g7H8i9J",  # Discord Webhook URL

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ twitch_miner = TwitchChannelPointsMiner(
             events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
                     Events.BET_LOSE, Events.CHAT_MENTION],                          # Only these events will be sent to the chat
             disable_notification=True,                                              # Revoke the notification (sound/vibration)
+            message_prefix="Essp "                                                  # Message prefix either False or a string (E.g. "User ") Useful when many miners using same messaging service. Add a space for formatting.
         ),
         discord=Discord(
             webhook_api="https://discord.com/api/webhooks/0123456789/0a1B2c3D4e5F6g7H8i9J",  # Discord Webhook URL
@@ -478,6 +479,7 @@ If you want to receive logs update on Telegram, initiate a new Telegram class, e
 | `token`       	 | string           |        	| Telegram API token @BotFather                                      |
 | `events`   	         | list             |       	| Only these events will be sent to the chat. Array of Event. or str |
 | `disable_notification` | bool             | false   	| Revoke the notification (sound/vibration)                          |
+| `message_prefix`       | string           | False     | Add a text string to the start of Telegram Message E.g. "User "    |
 
 
 ```python
@@ -487,6 +489,7 @@ Telegram(
     events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
                     Events.BET_LOSE, Events.CHAT_MENTION],
     disable_notification=True,
+    message_prefix=False
 )
 ```
 

--- a/TwitchChannelPointsMiner/classes/Telegram.py
+++ b/TwitchChannelPointsMiner/classes/Telegram.py
@@ -9,7 +9,7 @@ class Telegram(object):
     __slots__ = ["chat_id", "telegram_api", "events", "disable_notification", "message_prefix"]
 
     def __init__(
-        self, chat_id: int, token: str, message_prefix: str, events: list, disable_notification: bool = False
+        self, chat_id: int, token: str, events: list, message_prefix: str = None, disable_notification: bool = False
     ):
         self.chat_id = chat_id
         self.telegram_api = f"https://api.telegram.org/bot{token}/sendMessage"

--- a/TwitchChannelPointsMiner/classes/Telegram.py
+++ b/TwitchChannelPointsMiner/classes/Telegram.py
@@ -6,7 +6,7 @@ from TwitchChannelPointsMiner.classes.Settings import Events
 
 
 class Telegram(object):
-    __slots__ = ["chat_id", "telegram_api", "events", "disable_notification"]
+    __slots__ = ["chat_id", "telegram_api", "events", "disable_notification", "message_prefix"]
 
     def __init__(
         self, chat_id: int, token: str, events: list, disable_notification: bool = False
@@ -15,8 +15,13 @@ class Telegram(object):
         self.telegram_api = f"https://api.telegram.org/bot{token}/sendMessage"
         self.events = [str(e) for e in events]
         self.disable_notification = disable_notification
-
+        if not message_prefix or message_prefix == False:
+            self.message_prefix = ""
+        else:
+            self.message_prefix = message_prefix
+            
     def send(self, message: str, event: Events) -> None:
+        message = self.message_prefix + message
         if str(event) in self.events:
             requests.post(
                 url=self.telegram_api,

--- a/TwitchChannelPointsMiner/classes/Telegram.py
+++ b/TwitchChannelPointsMiner/classes/Telegram.py
@@ -9,7 +9,7 @@ class Telegram(object):
     __slots__ = ["chat_id", "telegram_api", "events", "disable_notification", "message_prefix"]
 
     def __init__(
-        self, chat_id: int, token: str, events: list, disable_notification: bool = False
+        self, chat_id: int, token: str, message_prefix: str, events: list, disable_notification: bool = False
     ):
         self.chat_id = chat_id
         self.telegram_api = f"https://api.telegram.org/bot{token}/sendMessage"

--- a/example.py
+++ b/example.py
@@ -46,6 +46,7 @@ twitch_miner = TwitchChannelPointsMiner(
             events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
                     Events.BET_LOSE, Events.CHAT_MENTION],                          # Only these events will be sent to the chat
             disable_notification=True,                                              # Revoke the notification (sound/vibration)
+            message_prefix=False                                                  # Message prefix either False or a string (E.g. "User ") Useful when many miners using same messaging service. Add a space for formatting.
         ),
         discord=Discord(
             webhook_api="https://discord.com/api/webhooks/0123456789/0a1B2c3D4e5F6g7H8i9J",  # Discord Webhook URL


### PR DESCRIPTION
# Description
This enhancement adds a prefix to Telegram messages. 
When running multiple miners using one Telegram chat, it is difficult to discern which miner the message relates to. Much like the console_username parameter, this adds the ability to identify the messages.
However, this does not use the username by default (concern about long usernames creating overly verbose messages).

Opt-In by default: Does nothing unless it is specifically configured.
If the user configures a text string, it will be pre-pended into message that send to the Telegram chat.
If the configuration line is not present, it continues normally.

Works particularly well with a space after the text, so I added this in the comment text in example.py and the readme.md

I have updated what I believe needed to be updated.

Fixes # (discussion) Partly resolves my own discussion - [#376 ](https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/discussions/376) 
- After thinking more deeply, I realised that putting the full twitch username in the message was not a great idea as it would be overly verbose for a Telegram message. I subsequently thought that having the ability to create a short string the prefix the messages with will help to identify the miner. I personally use the first characters of the miner name.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- I have tested this locally with multiple miners and it is working successfully. Messages are prefixed.
- I have commented out the message_prefix in run.py configuration - works as normal
- I have deleted the message_prefix configuration line in run.py - works as normal

To test:
1. Use a miner with a configuration with configured Telegram messaging.
2. Change the message_prefix option in the Telegram section of run.py from False to "User "
3. Start miner
4. Check Telegram messages
5. If successful, messages will be prefixed with "User "


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (README.md)
- [X] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt

# Notes
- I didn't think that my few lines of code warranted comments, but I updated the readme.md and example.py to suit with some comments in there.
- Nothing is changed in the requirements I believe as this is a very simple change.
- This is my first Pull Request, hopefully I got it sort of right.
- I don't use other messaging services, but this could work for others as well.