### PR TITLE
Update Twitch.py streak time to 1

### DIFF
--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -433,7 +433,7 @@ class Twitch(object):
                                     )
                                     > 30
                                 )
-                                and streamers[index].stream.minute_watched < 7
+                                and streamers[index].stream.minute_watched < 1
                             ):
                                 streamers_watching.append(index)
                                 if len(streamers_watching) == 2:


### PR DESCRIPTION
# Description

Catching streaks was causing #284 to stall out and constantly try to catch streaks. In my testing streaks take less than 1 minute to catch. Reducing from 7 mins to 1 allows the miner to be more efficient about switching back to what it was doing prior to catching the streak.

Fixes #284 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran with this set as described for over a month and observed the miner did not have issues catching streaks.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (README.md)
- [X] My changes generate no new warnings
- [X] Any dependent changes have been updated in requirements.txt
