### PR TITLE
Analytics fix

### DIFF
--- a/TwitchChannelPointsMiner/classes/AnalyticsServer.py
+++ b/TwitchChannelPointsMiner/classes/AnalyticsServer.py
@@ -28,10 +28,12 @@ def aggregate(df, freq="30Min"):
     df_base_events = df[(df.z == "Watch") | (df.z == "Claim")]
     df_other_events = df[(df.z != "Watch") & (df.z != "Claim")]
 
-    be = df_base_events.groupby([pd.Grouper(freq=freq, key="datetime"), "z"]).max()
+    be = df_base_events.groupby(
+        [pd.Grouper(freq=freq, key="datetime"), "z"]).max()
     be = be.reset_index()
 
-    oe = df_other_events.groupby([pd.Grouper(freq=freq, key="datetime"), "z"]).max()
+    oe = df_other_events.groupby(
+        [pd.Grouper(freq=freq, key="datetime"), "z"]).max()
     oe = oe.reset_index()
 
     result = pd.concat([be, oe])
@@ -52,13 +54,12 @@ def filter_datas(start_date, end_date, datas):
     ).replace(hour=23, minute=59, second=59).timestamp() * 1000
 
     original_series = datas["series"]
-    
+
     if "series" in datas:
         df = pd.DataFrame(datas["series"])
         df["datetime"] = pd.to_datetime(df.x // 1000, unit="s")
 
         df = df[(df.x >= start_date) & (df.x <= end_date)]
-
 
         datas["series"] = (
             df.drop(columns="datetime")
@@ -69,19 +70,21 @@ def filter_datas(start_date, end_date, datas):
         datas["series"] = []
 
     # If no data is found within the timeframe, that usually means the streamer hasn't streamed within that timeframe
-    # We create a series that shows up as a straight line on the dashboard, with 'No Stream' as labels 
-    if len(datas["series"]) == 0: 
-        new_end_date = start_date; 
-        new_start_date = 0; 
+    # We create a series that shows up as a straight line on the dashboard, with 'No Stream' as labels
+    if len(datas["series"]) == 0:
+        new_end_date = start_date
+        new_start_date = 0
         df = pd.DataFrame(original_series)
         df["datetime"] = pd.to_datetime(df.x // 1000, unit="s")
 
         # Attempt to get the last known balance from before the provided timeframe
         df = df[(df.x >= new_start_date) & (df.x <= new_end_date)]
-        last_balance = df.drop(columns="datetime").sort_values(by=["x", "y"], ascending=True).to_dict("records")[-1]['y'] 
+        last_balance = df.drop(columns="datetime").sort_values(
+            by=["x", "y"], ascending=True).to_dict("records")[-1]['y']
 
-        datas["series"] = [{'x': start_date, 'y': last_balance, 'z': 'No Stream'}, {'x': end_date, 'y': last_balance, 'z': 'No Stream'}]; 
-        
+        datas["series"] = [{'x': start_date, 'y': last_balance, 'z': 'No Stream'}, {
+            'x': end_date, 'y': last_balance, 'z': 'No Stream'}]
+
     if "annotations" in datas:
         df = pd.DataFrame(datas["annotations"])
         df["datetime"] = pd.to_datetime(df.x // 1000, unit="s")
@@ -105,37 +108,47 @@ def read_json(streamer, return_response=True):
 
     path = Settings.analytics_path
     streamer = streamer if streamer.endswith(".json") else f"{streamer}.json"
-    if return_response is True:
-        return Response(
-            json.dumps(
-                filter_datas(
-                    start_date, end_date, json.load(open(os.path.join(path, streamer)))
-                )
-            )
-            if streamer in streamers_available()
-            else [],
-            status=200,
-            mimetype="application/json",
-        )
-    return (
-        json.load(open(os.path.join(path, streamer)))
-        if streamer in streamers_available()
-        else []
-    )
+
+    # Check if the file exists before attempting to read it
+    if not os.path.exists(os.path.join(path, streamer)):
+        error_message = f"File '{streamer}' not found."
+        logger.error(error_message)
+        if return_response:
+            return Response(json.dumps({"error": error_message}), status=404, mimetype="application/json")
+        else:
+            return {"error": error_message}
+
+    try:
+        with open(os.path.join(path, streamer), 'r') as file:
+            data = json.load(file)
+    except json.JSONDecodeError as e:
+        error_message = f"Error decoding JSON in file '{streamer}': {str(e)}"
+        logger.error(error_message)
+        if return_response:
+            return Response(json.dumps({"error": error_message}), status=500, mimetype="application/json")
+        else:
+            return {"error": error_message}
+
+    # Handle filtering data, if applicable
+    filtered_data = filter_datas(start_date, end_date, data)
+    if return_response:
+        return Response(json.dumps(filtered_data), status=200, mimetype="application/json")
+    else:
+        return filtered_data
 
 
 def get_challenge_points(streamer):
     datas = read_json(streamer, return_response=False)
-    if datas != {}:
+    if "series" in datas and datas["series"]:
         return datas["series"][-1]["y"]
-    return 0
+    return 0  # Default value when 'series' key is not found or empty
 
 
 def get_last_activity(streamer):
     datas = read_json(streamer, return_response=False)
-    if datas != {}:
+    if "series" in datas and datas["series"]:
         return datas["series"][-1]["x"]
-    return 0
+    return 0  # Default value when 'series' key is not found or empty
 
 
 def json_all():
@@ -166,7 +179,8 @@ def streamers():
     return Response(
         json.dumps(
             [
-                {"name": s, "points": get_challenge_points(s), "last_activity": get_last_activity(s)}
+                {"name": s, "points": get_challenge_points(
+                    s), "last_activity": get_last_activity(s)}
                 for s in sorted(streamers_available())
             ]
         ),
@@ -182,7 +196,8 @@ def download_assets(assets_folder, required_files):
     for f in required_files:
         if os.path.isfile(os.path.join(assets_folder, f)) is False:
             if (
-                download_file(os.path.join("assets", f), os.path.join(assets_folder, f))
+                download_file(os.path.join("assets", f),
+                              os.path.join(assets_folder, f))
                 is True
             ):
                 logger.info(f"Downloaded {f}")
@@ -237,15 +252,18 @@ class AnalyticsServer(Thread):
             defaults={"refresh": refresh, "days_ago": days_ago},
             methods=["GET"],
         )
-        self.app.add_url_rule("/streamers", "streamers", streamers, methods=["GET"])
+        self.app.add_url_rule("/streamers", "streamers",
+                              streamers, methods=["GET"])
         self.app.add_url_rule(
             "/json/<string:streamer>", "json", read_json, methods=["GET"]
         )
-        self.app.add_url_rule("/json_all", "json_all", json_all, methods=["GET"])
+        self.app.add_url_rule("/json_all", "json_all",
+                              json_all, methods=["GET"])
 
     def run(self):
         logger.info(
             f"Analytics running on http://{self.host}:{self.port}/",
             extra={"emoji": ":globe_with_meridians:"},
         )
-        self.app.run(host=self.host, port=self.port, threaded=True, debug=False)
+        self.app.run(host=self.host, port=self.port,
+                     threaded=True, debug=False)

--- a/TwitchChannelPointsMiner/classes/entities/Streamer.py
+++ b/TwitchChannelPointsMiner/classes/entities/Streamer.py
@@ -209,9 +209,9 @@ class Streamer(object):
         event_type = event_type.upper()
         if event_type in ["WATCH_STREAK", "WIN", "PREDICTION_MADE", "LOSE"]:
             primary_color = (
-                "#45c1ff" #blue #45c1ff yellow #ffe045 green #36b535 red #ff4545 
+                "#45c1ff"  # blue #45c1ff yellow #ffe045 green #36b535 red #ff4545
                 if event_type == "WATCH_STREAK"
-                else ("#ffe045" if event_type == "PREDICTION_MADE" else ("#36b535" if event_type == "WIN" else "#ff4545")) 
+                else ("#ffe045" if event_type == "PREDICTION_MADE" else ("#36b535" if event_type == "WIN" else "#ff4545"))
             )
             data = {
                 "borderColor": primary_color,
@@ -236,14 +236,20 @@ class Streamer(object):
                 data.update({"z": event_type.replace("_", " ").title()})
 
         fname = os.path.join(Settings.analytics_path, f"{self.username}.json")
-        with self.mutex:
-            json_data = json.load(
-                open(fname, "r")) if os.path.isfile(fname) else {}
-            if key not in json_data:
-                json_data[key] = []
+        temp_fname = fname + '.temp'  # Temporary file name
 
-            json_data[key].append(data)
-            json.dump(json_data, open(fname, "w"), indent=4)
+        with self.mutex:
+            # Create and write to the temporary file
+            with open(temp_fname, "w") as temp_file:
+                json_data = json.load(
+                    open(fname, "r")) if os.path.isfile(fname) else {}
+                if key not in json_data:
+                    json_data[key] = []
+                json_data[key].append(data)
+                json.dump(json_data, temp_file, indent=4)
+
+            # Replace the original file with the temporary file
+            os.replace(temp_fname, fname)
 
     def leave_chat(self):
         if self.irc_chat is not None:


### PR DESCRIPTION
- app now handles broken analytic json files correctly and does not stop with an error because of them, they are now ignored.
- `__save_json` now utilizes a temp file `analytics/username/streamername.json.temp`:
  - Sometimes analytics files can be corrupted when written to disk. Solution:
    - First, write the data to a temporary file. After that, there will be two files on the disk - a new one and a target one.
    - Rename temporary file to the target.
  - If the application is closed or crashes on the first step, the original file will remain untouched on the disk.
- 0-sized and broken json files are now error-logged (you will be also informed in the console), so you can find the problem files. It  will trigger when you'll try to open the analytics webpage.