### PR TITLE
Add ability to use Generic Webhook for logging Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,10 +526,10 @@ Discord(
 You can use generic webhook 
 
 | Key                	 | Type            	| Default 	| Description                                                        |
-|----------------------- |---------------------	|--------------	|------------------------------------------------------------------- |
-| `endpoint`          | string        	|           	|  webhook url 
-| `method`          | string        	|           	|  `POST` or `GET`                                                 |
-| `events`   	         | list             	|       	| Only these events will be sent to the chat. Array of Event. or str |
+|----------------------- |------------------|-----------|------------------------------------------------------------------- |
+| `endpoint`             | string        	|           | webhook url                                                        | 
+| `method`               | string        	|           | `POST` or `GET`                                                    |
+| `events`   	         | list             |       	| Only these events will be sent to the chat. Array of Event. or str |
 
 ```python
 Webhook(

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ from colorama import Fore
 from TwitchChannelPointsMiner import TwitchChannelPointsMiner
 from TwitchChannelPointsMiner.logger import LoggerSettings, ColorPalette
 from TwitchChannelPointsMiner.classes.Chat import ChatPresence
-from TwitchChannelPointsMiner.classes.Discord import 
+from TwitchChannelPointsMiner.classes.Discord import Discord
 from TwitchChannelPointsMiner.classes.Webhook import Webhook
 from TwitchChannelPointsMiner.classes.Telegram import Telegram
 from TwitchChannelPointsMiner.classes.Settings import Priority, Events, FollowersOrder

--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ from colorama import Fore
 from TwitchChannelPointsMiner import TwitchChannelPointsMiner
 from TwitchChannelPointsMiner.logger import LoggerSettings, ColorPalette
 from TwitchChannelPointsMiner.classes.Chat import ChatPresence
-from TwitchChannelPointsMiner.classes.Discord import Discord
+from TwitchChannelPointsMiner.classes.Discord import 
+from TwitchChannelPointsMiner.classes.Webhook import Webhook
 from TwitchChannelPointsMiner.classes.Telegram import Telegram
 from TwitchChannelPointsMiner.classes.Settings import Priority, Events, FollowersOrder
 from TwitchChannelPointsMiner.classes.entities.Bet import Strategy, BetSettings, Condition, OutcomeKeys, FilterCondition, DelayMode
@@ -516,6 +517,23 @@ If you want to receive log updates on Discord initialize a new Discord class, el
 ```python
 Discord(
    webhook_api="https://discord.com/api/webhooks/0123456789/0a1B2c3D4e5F6g7H8i9J",
+   events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
+                    Events.BET_LOSE, Events.CHAT_MENTION],
+)
+```
+
+#### Generic Webhook
+You can use generic webhook 
+
+| Key                	 | Type            	| Default 	| Description                                                        |
+|----------------------- |---------------------	|--------------	|------------------------------------------------------------------- |
+| `endpoint`          | string        	|           	|  webhook url 
+| `method`          | string        	|           	|  `POST` or `GET`                                                 |
+| `events`   	         | list             	|       	| Only these events will be sent to the chat. Array of Event. or str |
+
+```python
+Webhook(
+   endpoint="https://example.com/webhook",
    events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
                     Events.BET_LOSE, Events.CHAT_MENTION],
 )

--- a/README.md
+++ b/README.md
@@ -534,6 +534,7 @@ You can use generic webhook
 ```python
 Webhook(
    endpoint="https://example.com/webhook",
+   method="GET",
    events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
                     Events.BET_LOSE, Events.CHAT_MENTION],
 )

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -508,6 +508,7 @@ class Twitch(object):
                                                     "event": Events.DROP_STATUS,
                                                     "skip_telegram": True,
                                                     "skip_discord": True,
+                                                    "skip_webhook": True,
                                                     "skip_matrix": True,
                                                 },
                                             )
@@ -520,6 +521,11 @@ class Twitch(object):
 
                                         if Settings.logger.discord is not None:
                                             Settings.logger.discord.send(
+                                                "\n".join(drop_messages),
+                                                Events.DROP_STATUS,
+                                            )
+                                        if Settings.logger.webhook is not None:
+                                            Settings.logger.webhook.send(
                                                 "\n".join(drop_messages),
                                                 Events.DROP_STATUS,
                                             )

--- a/TwitchChannelPointsMiner/classes/Webhook.py
+++ b/TwitchChannelPointsMiner/classes/Webhook.py
@@ -1,0 +1,26 @@
+from textwrap import dedent
+
+import requests
+
+from TwitchChannelPointsMiner.classes.Settings import Events
+
+
+class Webhook(object):
+    __slots__ = ["endpoint", "method", "events"]
+
+    def __init__(self, endpoint: str, method: str, events: list):
+        self.endpoint = endpoint
+        self.events = [str(e) for e in events]
+
+    def send(self, message: str, event: Events) -> None:
+        
+        if str(event) in self.events:
+            url = self.endpoint + f"?event_name={str(event)}&message={message}" 
+            
+            if self.method.lower() == "get":
+                requests.get(url=url)
+            elif self.method.lower() == "post":
+                requests.post(url=url)
+            else:
+                raise ValueError("Invalid method., use POST or GET")
+

--- a/TwitchChannelPointsMiner/logger.py
+++ b/TwitchChannelPointsMiner/logger.py
@@ -12,6 +12,7 @@ import emoji
 from colorama import Fore, init
 
 from TwitchChannelPointsMiner.classes.Discord import Discord
+from TwitchChannelPointsMiner.classes.Webhook import Webhook
 from TwitchChannelPointsMiner.classes.Matrix import Matrix
 from TwitchChannelPointsMiner.classes.Settings import Events
 from TwitchChannelPointsMiner.classes.Telegram import Telegram
@@ -75,6 +76,7 @@ class LoggerSettings:
         "auto_clear",
         "telegram",
         "discord",
+        "webhook",
         "matrix",
         "pushover",
         "username"
@@ -94,6 +96,7 @@ class LoggerSettings:
         auto_clear: bool = True,
         telegram: Telegram or None = None,
         discord: Discord or None = None,
+        webhook: Webhook or None = None,
         matrix: Matrix or None = None,
         pushover: Pushover or None = None,
         username: str or None = None
@@ -110,6 +113,7 @@ class LoggerSettings:
         self.auto_clear = auto_clear
         self.telegram = telegram
         self.discord = discord
+        self.webhook = webhook
         self.matrix = matrix
         self.pushover = pushover
         self.username = username
@@ -185,6 +189,7 @@ class GlobalFormatter(logging.Formatter):
         if hasattr(record, "event"):
             self.telegram(record)
             self.discord(record)
+            self.webhook(record)
             self.matrix(record)
             self.pushover(record)
 
@@ -217,6 +222,16 @@ class GlobalFormatter(logging.Formatter):
             != "https://discord.com/api/webhooks/0123456789/0a1B2c3D4e5F6g7H8i9J"
         ):
             self.settings.discord.send(record.msg, record.event)
+
+    def webhook(self, record):
+        skip_webhook = False if hasattr(
+            record, "skip_webhook") is False else True
+
+        if (
+            self.settings.webhook is not None
+            and skip_webhook is False
+        ):
+            self.settings.webhook.send(record.msg, record.event)
 
     def matrix(self, record):
         skip_matrix = False if hasattr(

--- a/example.py
+++ b/example.py
@@ -6,6 +6,7 @@ from TwitchChannelPointsMiner import TwitchChannelPointsMiner
 from TwitchChannelPointsMiner.logger import LoggerSettings, ColorPalette
 from TwitchChannelPointsMiner.classes.Chat import ChatPresence
 from TwitchChannelPointsMiner.classes.Discord import Discord
+from TwitchChannelPointsMiner.classes.Webhook import Webhook
 from TwitchChannelPointsMiner.classes.Telegram import Telegram
 from TwitchChannelPointsMiner.classes.Matrix import Matrix
 from TwitchChannelPointsMiner.classes.Pushover import Pushover
@@ -49,6 +50,12 @@ twitch_miner = TwitchChannelPointsMiner(
         ),
         discord=Discord(
             webhook_api="https://discord.com/api/webhooks/0123456789/0a1B2c3D4e5F6g7H8i9J",  # Discord Webhook URL
+            events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
+                    Events.BET_LOSE, Events.CHAT_MENTION],                                  # Only these events will be sent to the chat
+        ),
+        webhook=Webhook(
+            endpoint="https://example.com/webhook",                                                                    # Webhook URL
+            method="GET",                                                                   # GET or POST
             events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
                     Events.BET_LOSE, Events.CHAT_MENTION],                                  # Only these events will be sent to the chat
         ),


### PR DESCRIPTION
add ability to use generic webhook for logging events

```python
Webhook(
   endpoint="https://example.com/webhook",
   method="GET",
   events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
                    Events.BET_LOSE, Events.CHAT_MENTION],
)
```