### PR TITLE
Fix Missing method on Generic Webhook

### DIFF
--- a/TwitchChannelPointsMiner/classes/Webhook.py
+++ b/TwitchChannelPointsMiner/classes/Webhook.py
@@ -10,6 +10,7 @@ class Webhook(object):
 
     def __init__(self, endpoint: str, method: str, events: list):
         self.endpoint = endpoint
+        self.method = method
         self.events = [str(e) for e in events]
 
     def send(self, message: str, event: Events) -> None:


### PR DESCRIPTION
Fix error missing method on generic webhook
<img width="580" alt="Screenshot 2024-01-13 090543" src="https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/assets/16457495/1bfb42a5-7471-4782-9549-3b6da72fab72">
