### PR TITLE
fix encoding when reading log file

### DIFF
--- a/TwitchChannelPointsMiner/classes/AnalyticsServer.py
+++ b/TwitchChannelPointsMiner/classes/AnalyticsServer.py
@@ -252,7 +252,7 @@ class AnalyticsServer(Thread):
             logs_path = os.path.join(Path().absolute(), "logs")
             log_file_path = os.path.join(logs_path, f"{username}.log")
             try:
-                with open(log_file_path, "r") as log_file:
+                with open(log_file_path, "r", encoding="utf-8") as log_file:
                     log_content = log_file.read()
 
                 # Extract new log entries since the last received index


### PR DESCRIPTION
fix character `→` in the log file
maybe fixed:
```
20/02/24 18:02:56 - ERROR - TwitchChannelPointsMiner.classes.AnalyticsServer - [log_exception]: Exception on /log [GET]
Traceback (most recent call last):
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python37\lib\site-packages\flask\app.py", line 2529, in wsgi_app
    response = self.full_dispatch_request()
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python37\lib\site-packages\flask\app.py", line 1825, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python37\lib\site-packages\flask\app.py", line 1823, in full_dispatch_request
    rv = self.dispatch_request()
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python37\lib\site-packages\flask\app.py", line 1799, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "C:\Users\Administrator\Documents\Twitch-Channel-Points-Miner-v2-master\TwitchChannelPointsMiner\classes\AnalyticsServer.py", line 256, in generate_log
    log_content = log_file.read()
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python37\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 43759: character maps to 
```