### PR TITLE
Fix regex for settings when getting spade url

### DIFF
--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -139,7 +139,7 @@ class Twitch(object):
                 streamer.streamer_url, headers=headers)
             response = main_page_request.text
             # logger.info(response)
-            regex_settings = "(https://static.twitchcdn.net/config/settings.*?js)"
+            regex_settings = "(https://static.twitchcdn.net/config/settings.*?js|https://assets.twitch.tv/config/settings.*?.js)"
             settings_url = re.search(regex_settings, response).group(1)
 
             settings_request = requests.get(settings_url, headers=headers)


### PR DESCRIPTION
# Description

PR based on the fix I did for my repo https://github.com/RakambdaOrg/ChannelPointsMiner/pull/750
Seems to have fixed the issue. For some channels the settings url is not hosted on the same host.

Fixes #487 (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

# How Has This Been Tested?

Didn't test it for this repo, I'll let people see if this works here too.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been updated in requirements.txt
