### PR TITLE
venv installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,8 +342,8 @@ twitch_miner.mine(followers=True, blacklist=["user1", "user2"])  # Blacklist exa
 1. Clone this repository `git clone https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2`
 2. Install all the requirements `pip install -r requirements.txt` . If you have problems with requirements, make sure to have at least Python3.6. You could also try to create a _virtualenv_ and then install all the requirements
 ```sh
-pip install virtualenv
-virtualenv -p python3 venv
+install python3-venv
+python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 ```


### PR DESCRIPTION
virtualenv has a tendency to not work causes more issues for users. as it will in a lot of cases keep saying the command doesn't exist

so its better to install python3-venv then create a venv with python3 -m venv venv

rest of the instructions still work. but would highly suggest to start recommending pipx instead and to use it with twitch miner as it creates a virtual environment during installation

or just use pipx in general as people will get an error on modern linux systems that say externally-managed-enviorment. which confuses people if you continue reading it python suggests pipx instead now as its techinally safer and cant cause system breakage

as for testing had to set it up on my ubuntu VPS. an these instructions does not work
