### PR TITLE
fix: Add missing "platform": "web" and "playerType": "frontpage" parameters and update persisted query hash for PlaybackAccessToken

### DIFF
--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -488,7 +488,7 @@ class Twitch(object):
                             "isVod": False,
                             "vodID": "",
                             # "playerType": "site"
-                            "playerType": "picture-by-picture",
+                            "playerType": "frontpage",
                             "platform": "web",
                         }
 

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -489,6 +489,7 @@ class Twitch(object):
                             "vodID": "",
                             # "playerType": "site"
                             "playerType": "picture-by-picture",
+                            "platform": "web",
                         }
 
                         # Get signature and value using the post_gql_request method

--- a/TwitchChannelPointsMiner/constants.py
+++ b/TwitchChannelPointsMiner/constants.py
@@ -54,7 +54,7 @@ class GQLOperations:
         "extensions": {
             "persistedQuery": {
                 "version": 1,
-                "sha256Hash": "3093517e37e4f4cb48906155bcd894150aef92617939236d2508f3375ab732ce",
+                "sha256Hash": "ed230aa1e33e07eebb8928504583da78a5173989fadfb1ac94be06a04f3cdbe9",
             }
         },
     }


### PR DESCRIPTION
# Description

This pull request fixes an issue where Twitch’s PlaybackAccessToken endpoint now requires a non-nullable "platform" parameter. Without this parameter, the response lacks the "data" key, which leads to a KeyError. Additionally, the previously used persisted query hash for PlaybackAccessToken was outdated, preventing Twitch from processing the request correctly.

By adding "platform": "web" to the request payload, updating the persisted query hash, and changing the playerType from "picture-by-picture" to "frontpage" (to match the official payload), the request is now processed successfully and the expected "data" field is returned.

Fixes # (Issue)
---
## Type of Change
Please remove any options that are not relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
---
# How Has This Been Tested?

1. **Local Testing:**  
   - The changes were run locally and verified using browser developer tools.  
   - Twitch now returns a response containing the `"data"` key, and the `KeyError` no longer occurs.
2. **Docker Environment (if applicable):**  
   - The logs show no `KeyError` and the miner functions as expected.
No additional dependencies or external changes were necessary for this fix.
---
# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been updated in `requirements.txt`