### PR TITLE
Add support for Ntfy notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ from TwitchChannelPointsMiner.classes.Discord import Discord
 from TwitchChannelPointsMiner.classes.Webhook import Webhook
 from TwitchChannelPointsMiner.classes.Telegram import Telegram
 from TwitchChannelPointsMiner.classes.Gotify import Gotify
+from TwitchChannelPointsMiner.classes.Ntfy import Ntfy
 from TwitchChannelPointsMiner.classes.Settings import Priority, Events, FollowersOrder
 from TwitchChannelPointsMiner.classes.entities.Bet import Strategy, BetSettings, Condition, OutcomeKeys, FilterCondition, DelayMode
 from TwitchChannelPointsMiner.classes.entities.Streamer import Streamer, StreamerSettings
@@ -266,6 +267,12 @@ twitch_miner = TwitchChannelPointsMiner(
             priority=8,
             events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
                     Events.BET_LOSE, Events.CHAT_MENTION], 
+        ),
+        ntfy=Ntfy(
+            endpoint="https://ntfy.example.com/mytopic",
+            priority=2,
+            events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
+                    Events.BET_LOSE, Events.CHAT_MENTION],
         )
     ),
     streamer_settings=StreamerSettings(
@@ -542,6 +549,26 @@ Webhook(
    method="GET",
    events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
                     Events.BET_LOSE, Events.CHAT_MENTION],
+)
+```
+
+#### Ntfy
+Receive messages via Ntfy (https://docs.ntfy.sh/)
+
+| Key                  | Type              | Default   | Description                                                            |
+|--------------------- |-------------------|-----------|------------------------------------------------------------------------|
+| `endpoint`           | string            |           | Ntfy instance url including the topic                                  |
+| `token`              | string            | `None`    | Your access token if the topic is protected, in the form of "tk_....." |
+| `priority`           | int               | `3`       | The Ntfy priority for the messages, ranging from 1 to 5                |
+| `events`             | list              |           | Only these events will be sent to the endpoint. Array of Event. or str |
+
+```python
+Ntfy(
+    endpoint="https://ntfy.example.com/mytopic",
+    token="tk_YOUR_ACCESS_TOKEN",
+    priority=4,
+    events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
+            Events.BET_LOSE, Events.CHAT_MENTION],
 )
 ```
 

--- a/TwitchChannelPointsMiner/classes/Ntfy.py
+++ b/TwitchChannelPointsMiner/classes/Ntfy.py
@@ -1,0 +1,31 @@
+from textwrap import dedent
+
+import requests
+
+from TwitchChannelPointsMiner.classes.Settings import Events
+
+
+class Ntfy(object):
+    __slots__ = ["endpoint", "events", "headers"]
+
+    def __init__(
+        self, endpoint: str, events: list, token: str or None = None, priority: int = 3
+    ):
+        self.endpoint = endpoint
+        self.events = [str(e) for e in events]
+
+        self.headers = {
+            "Priority": str(priority)
+        }
+
+        if token is not None:
+            self.headers["Authorization"] = f"Bearer {token}"
+
+    def send(self, message: str, event: Events) -> None:
+        if str(event) in self.events:
+            requests.post(
+                url=self.endpoint,
+                data=dedent(message),
+                headers=self.headers,
+            )
+

--- a/TwitchChannelPointsMiner/logger.py
+++ b/TwitchChannelPointsMiner/logger.py
@@ -18,6 +18,7 @@ from TwitchChannelPointsMiner.classes.Settings import Events
 from TwitchChannelPointsMiner.classes.Telegram import Telegram
 from TwitchChannelPointsMiner.classes.Pushover import Pushover
 from TwitchChannelPointsMiner.classes.Gotify import Gotify
+from TwitchChannelPointsMiner.classes.Ntfy import Ntfy
 from TwitchChannelPointsMiner.utils import remove_emoji
 
 
@@ -81,6 +82,7 @@ class LoggerSettings:
         "matrix",
         "pushover",
         "gotify",
+        "ntfy",
         "username"
     ]
 
@@ -102,6 +104,7 @@ class LoggerSettings:
         matrix: Matrix or None = None,
         pushover: Pushover or None = None,
         gotify: Gotify or None = None,
+        ntfy: Ntfy or None = None,
         username: str or None = None
     ):
         self.save = save
@@ -120,6 +123,7 @@ class LoggerSettings:
         self.matrix = matrix
         self.pushover = pushover
         self.gotify = gotify
+        self.ntfy = ntfy
         self.username = username
 
 
@@ -197,6 +201,7 @@ class GlobalFormatter(logging.Formatter):
             self.matrix(record)
             self.pushover(record)
             self.gotify(record)
+            self.ntfy(record)
 
             if self.settings.colored is True:
                 record.msg = (
@@ -275,6 +280,18 @@ class GlobalFormatter(logging.Formatter):
             != "https://example.com/message?token=TOKEN"
         ):
             self.settings.gotify.send(record.msg, record.event)
+
+    def ntfy(self, record):
+        skip_ntfy = False if hasattr(
+            record, "skip_ntfy") is False else True
+
+        if (
+            self.settings.ntfy is not None
+            and skip_ntfy is False
+            and self.settings.ntfy.endpoint
+            != "https://ntfy.example.com/mytopic"
+        ):
+            self.settings.ntfy.send(record.msg, record.event)
 
 
 def configure_loggers(username, settings):

--- a/example.py
+++ b/example.py
@@ -11,6 +11,7 @@ from TwitchChannelPointsMiner.classes.Telegram import Telegram
 from TwitchChannelPointsMiner.classes.Matrix import Matrix
 from TwitchChannelPointsMiner.classes.Pushover import Pushover
 from TwitchChannelPointsMiner.classes.Gotify import Gotify
+from TwitchChannelPointsMiner.classes.Ntfy import Ntfy
 from TwitchChannelPointsMiner.classes.Settings import Priority, Events, FollowersOrder
 from TwitchChannelPointsMiner.classes.entities.Bet import Strategy, BetSettings, Condition, OutcomeKeys, FilterCondition, DelayMode
 from TwitchChannelPointsMiner.classes.entities.Streamer import Streamer, StreamerSettings
@@ -79,6 +80,12 @@ twitch_miner = TwitchChannelPointsMiner(
             priority=8,
             events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
                     Events.BET_LOSE, Events.CHAT_MENTION], 
+        ),
+        ntfy=Ntfy(
+            endpoint="https://ntfy.example.com/mytopic",
+            token="tk_YOUR_ACCESS_TOKEN",
+            events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
+                    Events.BET_LOSE, Events.CHAT_MENTION],
         )
     ),
     streamer_settings=StreamerSettings(


### PR DESCRIPTION
# Description

Simply added another logging class for Ntfy (https://docs.ntfy.sh/). It's similar to Gotify, though not quite similar enough to reuse the existing class. No additional dependencies needed.

Fixes N/A (no issue)

## Type of change

New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually tested by running against my own self-hosted Ntfy instance. You can test against the public instance (https://ntfy.sh/yourtopichere), but there won't be any auth. The auth consists of a simple Authorization header that passes the standard `Bearer  <token>` for access tokens that you can generate from your Ntfy instance's web management console.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
