### PR TITLE
Fix webhook encoding

### DIFF
--- a/TwitchChannelPointsMiner/classes/Webhook.py
+++ b/TwitchChannelPointsMiner/classes/Webhook.py
@@ -4,6 +4,8 @@ import requests
 
 from TwitchChannelPointsMiner.classes.Settings import Events
 
+from urllib.parse import quote
+
 
 class Webhook(object):
     __slots__ = ["endpoint", "method", "events"]
@@ -14,10 +16,10 @@ class Webhook(object):
         self.events = [str(e) for e in events]
 
     def send(self, message: str, event: Events) -> None:
-        
+
         if str(event) in self.events:
-            url = self.endpoint + f"?event_name={str(event)}&message={message}" 
-            
+            url = self.endpoint + f"?event_name={str(event)}&message={quote(message)}"
+
             if self.method.lower() == "get":
                 requests.get(url=url)
             elif self.method.lower() == "post":


### PR DESCRIPTION
# Description

Added encoding of the message when sending a Webhook. Not encoding caused the message to be cut off on the `#` when Events.CHAT_MENTION was triggered.

Before :
![image](https://github.com/user-attachments/assets/05b483bf-1b39-42e4-bb58-4c12ec2be68c)
After : 
![image](https://github.com/user-attachments/assets/c6f62bad-0df7-46ad-b2bd-62edef0ee282)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I ran the script with my Webhook URL and looked at the message resulting from an Events.CHAT_MENTION. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
