### PR TITLE
Fixes #704

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,19 @@ twitch_miner = TwitchChannelPointsMiner(
             priority=8,
             events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
                     Events.BET_LOSE, Events.CHAT_MENTION], 
-        )
+        ),
+        hooks=[
+            Discord(
+                webhook_api="https://discord.com/api/webhooks/0123456789/0a1B2c3D4e5F6g7H8i9J",
+                events=[Events.GAIN_FOR_RAID, Events.GAIN_FOR_WATCH,
+                        Events.GAIN_FOR_CLAIM, Events.GAIN_FOR_WATCH_STREAK],
+            ),
+            Discord(
+                webhook_api="https://discord.com/api/webhooks/9876543210/78ad737ba0e951cdfbde",
+                events=[Events.BET_GENERAL, Events.BET_LOSE,
+                        Events.BET_WIN, Events.BET_REFUND],
+            )
+        ]                                                                             # Add any additional log hooks to this list, in this example 2 different discord webhooks get 2 different types of Events
     ),
     streamer_settings=StreamerSettings(
         make_predictions=True,                  # If you want to Bet / Make prediction
@@ -444,20 +456,25 @@ Available values are the following:
 You can combine all priority but keep in mind that use `ORDER` and `POINTS_ASCENDING` in the same settings doesn't make sense.
 
 ### LoggerSettings
-| Key             	| Type            	| Default                        	                                  | Description                                                                          	                                                                                                  |
-|-----------------	|-----------------	|-------------------------------------------------------------------- |------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `save`          	| bool            	| True                           	                                  | If you want to save logs in file (suggested)                                         	                                                                                                  |
-| `less`          	| bool            	| False                          	                                  | Reduce the logging format and message verbosity [#10](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/10)                                                               |
-| `console_level` 	| level 	        | logging.INFO                   	                                  | Level of logs in terminal - Use logging.DEBUG for more helpful messages.             	                                                                                                  |
-| `console_username`| bool 	            | False                   	                                          | Adds a username to every log line in the console if True. [#602](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/602)|
-| `time_zone`| str 	            | None                   	                                          | Set a specific time zone for console and file loggers. Use tz database names. Example: "America/Denver" https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/issues/205|
-| `file_level`    	| level 	        | logging.DEBUG                  	                                  | Level of logs in file save - If you think the log file it's too big, use logging.INFO 	                                                                                                  |
-| `emoji`         	| bool            	| For Windows is False else True 	                                  | On Windows, we have a problem printing emoji. Set to false if you have a problem      	                                                                                                  |
-| `colored`         | bool            	| True 	                                                              | If you want to print colored text [#45](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/45) [#82](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/82) |
-| `auto_clear`      | bool            	| True 	                                                              | Create a file rotation handler with interval = 1D and backupCount = 7 [#215](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/215)                                       |
-| `color_palette`   | ColorPalette      | All messages are Fore.RESET except WIN and LOSE bet (GREEN and RED) | Create your custom color palette. Read more above.      	                                                                                                                              |
-| `telegram`        | Telegram          | None                                                                | (Optional) Receive Telegram updates for multiple events list [#233](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/233)                                                           |
-| `discord`         | Discord          | None                                                                 | (Optional) Receive Discord updates for multiple events list [#320](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/320)                                                           |
+| Key             	  | Type            | Default                                                             | Description                                                                                                                                                                               |
+|--------------------|-----------------|---------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `save`          	  | bool            | True                                                                | If you want to save logs in file (suggested)                                                                                                                                              |
+| `less`          	  | bool            | False                                                               | Reduce the logging format and message verbosity [#10](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/10)                                                               |
+| `console_level` 	  | level           | logging.INFO                                                        | Level of logs in terminal - Use logging.DEBUG for more helpful messages.                                                                                                                  |
+| `console_username` | bool            | False                                                               | Adds a username to every log line in the console if True. [#602](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/602)                                                   |
+| `time_zone`        | str             | None                                                                | Set a specific time zone for console and file loggers. Use tz database names. Example: "America/Denver" https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/issues/205             |
+| `file_level`    	  | level           | logging.DEBUG                                                       | Level of logs in file save - If you think the log file it's too big, use logging.INFO                                                                                                     |
+| `emoji`         	  | bool            | For Windows is False else True                                      | On Windows, we have a problem printing emoji. Set to false if you have a problem                                                                                                          |
+| `colored`          | bool            | True                                                                | If you want to print colored text [#45](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/45) [#82](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/82) |
+| `auto_clear`       | bool            | True                                                                | Create a file rotation handler with interval = 1D and backupCount = 7 [#215](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/215)                                       |
+| `color_palette`    | ColorPalette    | All messages are Fore.RESET except WIN and LOSE bet (GREEN and RED) | Create your custom color palette. Read more above.                                                                                                                                        |
+| `telegram`         | Telegram        | None                                                                | (Optional) Receive Telegram updates for multiple events list [#233](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/233)                                                |
+| `discord`          | Discord         | None                                                                | (Optional) Receive Discord updates for multiple events list [#320](https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues/320)                                                 |
+| `webhook`          | Webhook         | None                                                                | (Optional) Receive Generic Webhook updates for multiple events list [#424](https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/pull/424)                                           |
+| `matrix`           | Matrix          | None                                                                | (Optional) Receive Matrix updates for multiple events list [#228](https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/pull/228)                                                    |
+| `pushover`         | Pushover        | None                                                                | (Optional) Receive Pushover updates for multiple events list [#151](https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/issues/151)                                                |
+| `gotify`           | Gotify          | None                                                                | (Optional) Receive Gotify updates for multiple events list [#585](https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/pull/585)                                                    |
+| `hooks`            | list[EventHook] | None                                                                | (Optional) Receive any of the above hook types (Telegram, Discord, etc...) updates for multiple events list [#704](https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/issues/704) |
 
 #### Color Palette
 Now you can customize the color of the terminal message. We have created a default ColorPalette that provide all the message with `DEFAULT (RESET)` color and the `BET_WIN` and `BET_LOSE` message `GREEN` and `RED` respectively. You can change the colors of all `Events` enum class. The colors allowed are all the Fore color from Colorama: `BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE, RESET.`
@@ -543,6 +560,41 @@ Webhook(
    events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
                     Events.BET_LOSE, Events.CHAT_MENTION],
 )
+```
+
+#### Hooks
+
+You can specify additional hooks in this list. The below example is just an example, you can add as many instances of
+any EventHook subclass (Telegram, Discord, Webhook, Matrix, Pushover, and Gotify) as you like. Additionally, you could
+just use this list, foregoing the named hooks.
+
+```python
+[
+    Telegram(
+        chat_id=123456789,
+        token="123456789:shfuihreuifheuifhiu34578347",
+        events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
+                        Events.BET_LOSE, Events.CHAT_MENTION],
+        disable_notification=True,
+    ),
+    Discord(
+        webhook_api="https://discord.com/api/webhooks/0123456789/0a1B2c3D4e5F6g7H8i9J",
+        events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
+                        Events.BET_LOSE, Events.CHAT_MENTION],
+    ),
+    Discord(
+        webhook_api="https://discord.com/api/webhooks/9876543210/78ad737ba0e951cdfbde",
+        events=[Events.BET_GENERAL, Events.BET_LOSE,
+                        Events.BET_WIN, Events.BET_REFUND],
+    ),
+    Webhook(
+        endpoint="https://example.com/webhook",
+        method="GET",
+        events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
+                        Events.BET_LOSE, Events.CHAT_MENTION],
+    )
+]
+
 ```
 
 

--- a/TwitchChannelPointsMiner/classes/Discord.py
+++ b/TwitchChannelPointsMiner/classes/Discord.py
@@ -2,13 +2,20 @@ from textwrap import dedent
 
 import requests
 
+from TwitchChannelPointsMiner.classes.EventHook import LogAttributeValidatingEventHook
 from TwitchChannelPointsMiner.classes.Settings import Events
 
 
-class Discord(object):
+class Discord(LogAttributeValidatingEventHook):
+    __invalid_urls = {
+        "https://discord.com/api/webhooks/0123456789/0a1B2c3D4e5F6g7H8i9J",
+        "https://discord.com/api/webhooks/9876543210/78ad737ba0e951cdfbde"
+    }
+
     __slots__ = ["webhook_api", "events"]
 
     def __init__(self, webhook_api: str, events: list):
+        super().__init__("skip_discord")
         self.webhook_api = webhook_api
         self.events = [str(e) for e in events]
 
@@ -22,3 +29,6 @@ class Discord(object):
                     "avatar_url": "https://i.imgur.com/X9fEkhT.png",
                 },
             )
+
+    def validate_record(self, record):
+        return super().validate_record(record) and self.webhook_api not in Discord.__invalid_urls

--- a/TwitchChannelPointsMiner/classes/EventHook.py
+++ b/TwitchChannelPointsMiner/classes/EventHook.py
@@ -1,0 +1,89 @@
+import abc
+
+from TwitchChannelPointsMiner.classes.Settings import Events
+
+
+class EventHook(abc.ABC):
+    """
+    Abstract base class for an object that can send event messages. e.g.:
+
+        .. code-block:: python
+
+        class ExampleEventHook(EventHook):
+            def __init__(self, webhook_api: str):
+                self.webhook_api = webhook_api
+
+            def send(self, message: str, event: Events) -> None:
+                requests.post(self.webhook_api, data={content=message})
+
+            def validate_record(self, record) -> bool:
+                return True
+
+    In this example `ExampleEventHook` sends the message to some remote webhook that exists at `webhook_api`, all
+    messages get sent because all log records return `True` from `validate_record`.
+    """
+
+    @abc.abstractmethod
+    def send(self, message: str, event: Events) -> None:
+        """
+        Sends a message for a give type of Event.
+        :param message: The message to send.
+        :param event: The event type of the message.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def validate_record(self, record) -> bool:
+        """
+        Validates a log record. Returns True if the record is valid and False otherwise.
+        :param record: Log record to validate.
+        :return: True if the record is valid and False otherwise.
+        """
+        raise NotImplementedError()
+
+    def validate_and_send(self, record) -> None:
+        """
+        Validates a log record and sends it if it's valid.
+        :param record: Log record to validate and send.
+        """
+        if self.validate_record(record):
+            self.send(record.msg, record.event)
+
+
+class LogAttributeValidatingEventHook(EventHook, abc.ABC):
+    """
+    Abstract EventHook that validates log records based on whether a particular attribute is set. e.g.:
+
+        .. code-block:: python
+
+        class ExampleHook(LogAttributeValidatingEventHook):
+            def __init__(self):
+                super().__init__("skip_example_hook")
+
+            def send(self, message: str, event: Events) -> None:
+                ...
+
+        record = {
+            'msg': 'Hello World!',
+            'skip_example_hook': True
+        }
+        hook = ExampleHook()
+        hook.validate_record(record)# Returns False
+
+    In this example `ExampleHook` passes "skip_example_hook" to `super().__init__`, later when `validate_record` is
+    called the record passed contains an attribute with that name and so returns `False`.
+    """
+
+    def __init__(self, skip_attr_name: str):
+        """
+        :param skip_attr_name: The name of the attribute to check for on log records.
+        """
+        self.skip_attr_name = skip_attr_name
+
+    def validate_record(self, record):
+        """
+        Returns `False` if the record contains an attribute with the same name as the value of `self.skip_attr_name`.
+        :param record: The log record to validate.
+        :return: True if the record is valid.
+        """
+        return False if hasattr(record, self.skip_attr_name) is True else True

--- a/TwitchChannelPointsMiner/classes/Gotify.py
+++ b/TwitchChannelPointsMiner/classes/Gotify.py
@@ -2,12 +2,15 @@ from textwrap import dedent
 
 import requests
 
+from TwitchChannelPointsMiner.classes.EventHook import LogAttributeValidatingEventHook
 from TwitchChannelPointsMiner.classes.Settings import Events
 
-class Gotify(object):
+
+class Gotify(LogAttributeValidatingEventHook):
     __slots__ = ["endpoint", "priority", "events"]
 
     def __init__(self, endpoint: str, priority: int, events: list):
+        super().__init__("skip_gotify")
         self.endpoint = endpoint
         self.priority = priority
         self.events = [str(e) for e in events]
@@ -21,3 +24,6 @@ class Gotify(object):
                     "priority": self.priority
                 },
             )
+
+    def validate_record(self, record):
+        return super().validate_record(record) and self.endpoint != "https://example.com/message?token=TOKEN"

--- a/TwitchChannelPointsMiner/classes/Matrix.py
+++ b/TwitchChannelPointsMiner/classes/Matrix.py
@@ -4,13 +4,15 @@ import logging
 import requests
 from urllib.parse import quote
 
+from TwitchChannelPointsMiner.classes.EventHook import LogAttributeValidatingEventHook
 from TwitchChannelPointsMiner.classes.Settings import Events
 
 
-class Matrix(object):
+class Matrix(LogAttributeValidatingEventHook):
     __slots__ = ["access_token", "homeserver", "room_id", "events"]
 
     def __init__(self, username: str, password: str, homeserver: str, room_id: str, events: list):
+        super().__init__("skip_matrix")
         self.homeserver = homeserver
         self.room_id = quote(room_id)
         self.events = [str(e) for e in events]
@@ -38,3 +40,6 @@ class Matrix(object):
                     "msgtype": "m.text"
                 }
             )
+
+    def validate_record(self, record):
+        return super().validate_record(record) and self.room_id != "..." and self.access_token

--- a/TwitchChannelPointsMiner/classes/Pushover.py
+++ b/TwitchChannelPointsMiner/classes/Pushover.py
@@ -2,16 +2,18 @@ from textwrap import dedent
 
 import requests
 
+from TwitchChannelPointsMiner.classes.EventHook import LogAttributeValidatingEventHook
 from TwitchChannelPointsMiner.classes.Settings import Events
 
 
-class Pushover(object):
+class Pushover(LogAttributeValidatingEventHook):
     __slots__ = ["userkey", "token", "priority", "sound", "events"]
 
     def __init__(self, userkey: str, token: str, priority, sound, events: list):
+        super().__init__("skip_pushover")
         self.userkey = userkey
         self.token = token
-        self. priority = priority
+        self.priority = priority
         self.sound = sound
         self.events = [str(e) for e in events]
 
@@ -28,3 +30,8 @@ class Pushover(object):
                     "sound": self.sound,
                 },
             )
+
+    def validate_record(self, record):
+        return super().validate_record(
+            record
+        ) and self.userkey != "YOUR-ACCOUNT-TOKEN" and self.token != "YOUR-APPLICATION-TOKEN"

--- a/TwitchChannelPointsMiner/classes/Telegram.py
+++ b/TwitchChannelPointsMiner/classes/Telegram.py
@@ -2,15 +2,17 @@ from textwrap import dedent
 
 import requests
 
+from TwitchChannelPointsMiner.classes.EventHook import LogAttributeValidatingEventHook
 from TwitchChannelPointsMiner.classes.Settings import Events
 
 
-class Telegram(object):
+class Telegram(LogAttributeValidatingEventHook):
     __slots__ = ["chat_id", "telegram_api", "events", "disable_notification"]
 
     def __init__(
         self, chat_id: int, token: str, events: list, disable_notification: bool = False
     ):
+        super().__init__("skip_telegram")
         self.chat_id = chat_id
         self.telegram_api = f"https://api.telegram.org/bot{token}/sendMessage"
         self.events = [str(e) for e in events]
@@ -27,3 +29,6 @@ class Telegram(object):
                     "disable_notification": self.disable_notification,  # no sound, notif just in tray
                 },
             )
+
+    def validate_record(self, record):
+        return super().validate_record(record) and self.chat_id != 123456789

--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -620,31 +620,16 @@ class Twitch(object):
                                                     "skip_discord": True,
                                                     "skip_webhook": True,
                                                     "skip_matrix": True,
-                                                    "skip_gotify": True
+                                                    "skip_gotify": True,
+                                                    "skip_pushover": True
                                                 },
                                             )
 
-                                        if Settings.logger.telegram is not None:
-                                            Settings.logger.telegram.send(
-                                                "\n".join(drop_messages),
-                                                Events.DROP_STATUS,
-                                            )
+                                        if len(Settings.logger.hooks) > 0:
+                                            combined_message = "\n".join(drop_messages)
+                                            for hook in Settings.logger.hooks:
+                                                hook.send(combined_message, Events.DROP_STATUS)
 
-                                        if Settings.logger.discord is not None:
-                                            Settings.logger.discord.send(
-                                                "\n".join(drop_messages),
-                                                Events.DROP_STATUS,
-                                            )
-                                        if Settings.logger.webhook is not None:
-                                            Settings.logger.webhook.send(
-                                                "\n".join(drop_messages),
-                                                Events.DROP_STATUS,
-                                            )
-                                        if Settings.logger.gotify is not None:
-                                            Settings.logger.gotify.send(
-                                                "\n".join(drop_messages),
-                                                Events.DROP_STATUS,
-                                            )
 
                     except requests.exceptions.ConnectionError as e:
                         logger.error(

--- a/TwitchChannelPointsMiner/classes/Webhook.py
+++ b/TwitchChannelPointsMiner/classes/Webhook.py
@@ -1,26 +1,28 @@
-from textwrap import dedent
-
 import requests
 
+from TwitchChannelPointsMiner.classes.EventHook import LogAttributeValidatingEventHook
 from TwitchChannelPointsMiner.classes.Settings import Events
 
 
-class Webhook(object):
+class Webhook(LogAttributeValidatingEventHook):
     __slots__ = ["endpoint", "method", "events"]
 
     def __init__(self, endpoint: str, method: str, events: list):
+        super().__init__("skip_webhook")
         self.endpoint = endpoint
         self.method = method
         self.events = [str(e) for e in events]
 
     def send(self, message: str, event: Events) -> None:
-        
         if str(event) in self.events:
-            url = self.endpoint + f"?event_name={str(event)}&message={message}" 
-            
+            url = self.endpoint + f"?event_name={str(event)}&message={message}"
+
             if self.method.lower() == "get":
                 requests.get(url=url)
             elif self.method.lower() == "post":
                 requests.post(url=url)
             else:
                 raise ValueError("Invalid method, use POST or GET")
+
+    def validate_record(self, record):
+        return super().validate_record(record) and self.endpoint != "https://example.com/webhook"

--- a/example.py
+++ b/example.py
@@ -79,7 +79,19 @@ twitch_miner = TwitchChannelPointsMiner(
             priority=8,
             events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
                     Events.BET_LOSE, Events.CHAT_MENTION], 
-        )
+        ),
+        hooks=[
+            Discord(
+                webhook_api="https://discord.com/api/webhooks/0123456789/0a1B2c3D4e5F6g7H8i9J",
+                events=[Events.GAIN_FOR_RAID, Events.GAIN_FOR_WATCH,
+                        Events.GAIN_FOR_CLAIM, Events.GAIN_FOR_WATCH_STREAK],
+            ),
+            Discord(
+                webhook_api="https://discord.com/api/webhooks/9876543210/78ad737ba0e951cdfbde",
+                events=[Events.BET_GENERAL, Events.BET_LOSE,
+                        Events.BET_WIN, Events.BET_REFUND],
+            )
+        ]                                                                             # Add any additional log hooks to this list, in this example 2 different discord webhooks get 2 different types of Events
     ),
     streamer_settings=StreamerSettings(
         make_predictions=True,                  # If you want to Bet / Make prediction


### PR DESCRIPTION
# Description

Creates an abstract class `EventHook` for the log hook classes (`Discord`, `Gotify`, `Matrix`, `Pushover`, `Telegram`, and `Webhook`) and adds a `list[EventHook]` to the `LoggerSettings`. This enables users to specify as many hooks as required in their settings.

I've kept the old named hooks in the settings object to maintain backwards compatibility with existing user's settings.

This also potentially fixes a bug with the `Pushover` hook. The `DROP_STATUS` logs get combined into a single message for the other hooks, I think this got missed when the `Pushover` hook was written but nobody has made an issue about it so maybe it's fine.

I considered making the hooks into log handlers directly but that would have meant either inefficiently duplicating the work the log formatter does or having to rework the log formatter. It would also make it more difficult to combine those `DROP_STATUS` logs. This can still be done later if people think it would be better.

There is potentially another bit of code that could be abstracted, the hooks' `send` methods all first check if the given `event` is in the hook's `self.events`. This could be moved to the `validate_record` step to avoid having to redo this step for each hook. I've left it alone for now because I wanted to avoid touching the `send` methods if possible.

Finally, I think the reason `Gotify.py` looks like I've replaced the whole file is because it originally had windows line endings, I reformatted the file to use unix ones because git was complaining about it.

Fixes #704

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I added multiple Discord hooks to the list with different event filters and saw the desired events went to the correct hooks. I also tested using the existing named hook alongside this and it also worked as expected. I did not test with the other hook classes.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
