### PR TITLE
Fixes issue where the same streamer could fill both watch slots.

### DIFF
--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -392,20 +392,30 @@ class Twitch(object):
                         # Please perform a manually update and check if the user it's online
                         self.check_streamer_online(streamers[index])
 
-                streamers_watching = []
-                for prior in priority:
-                    if prior == Priority.ORDER and len(streamers_watching) < 2:
-                        # Get the first 2 items, they are already in order
-                        streamers_watching += streamers_index[:2]
+                """
+                Twitch has a limit - you can't watch more than 2 channels at one time.
+                We'll take the first two streamers from the final list as they have the highest priority.
+                """
+                max_watch_amount = 2
+                streamers_watching = set()
 
-                    elif (
-                        prior in [Priority.POINTS_ASCENDING,
-                                  Priority.POINTS_DESCENDING]
-                        and len(streamers_watching) < 2
-                    ):
+                def remaining_watch_amount():
+                    return max_watch_amount - len(streamers_watching)
+
+                for prior in priority:
+                    if remaining_watch_amount() <= 0:
+                        break
+
+                    if prior == Priority.ORDER:
+                        # Get the first 2 items, they are already in order
+                        streamers_watching.update(streamers_index[:remaining_watch_amount()])
+
+                    elif prior in [Priority.POINTS_ASCENDING, Priority.POINTS_DESCENDING]:
                         items = [
-                            {"points": streamers[index].channel_points,
-                                "index": index}
+                            {
+                                "points": streamers[index].channel_points,
+                                "index": index
+                            }
                             for index in streamers_index
                         ]
                         items = sorted(
@@ -415,10 +425,9 @@ class Twitch(object):
                                 True if prior == Priority.POINTS_DESCENDING else False
                             ),
                         )
-                        streamers_watching += [item["index"]
-                                               for item in items][:2]
+                        streamers_watching.update([item["index"] for item in items][:remaining_watch_amount()])
 
-                    elif prior == Priority.STREAK and len(streamers_watching) < 2:
+                    elif prior == Priority.STREAK:
                         """
                         Check if we need need to change priority based on watch streak
                         Viewers receive points for returning for x consecutive streams.
@@ -441,18 +450,18 @@ class Twitch(object):
                                 # fix #425
                                 and streamers[index].stream.minute_watched < 7
                             ):
-                                streamers_watching.append(index)
-                                if len(streamers_watching) == 2:
+                                streamers_watching.add(index)
+                                if remaining_watch_amount() <= 0:
                                     break
 
-                    elif prior == Priority.DROPS and len(streamers_watching) < 2:
+                    elif prior == Priority.DROPS:
                         for index in streamers_index:
                             if streamers[index].drops_condition() is True:
-                                streamers_watching.append(index)
-                                if len(streamers_watching) == 2:
+                                streamers_watching.add(index)
+                                if remaining_watch_amount() <= 0:
                                     break
 
-                    elif prior == Priority.SUBSCRIBED and len(streamers_watching) < 2:
+                    elif prior == Priority.SUBSCRIBED:
                         streamers_with_multiplier = [
                             index
                             for index in streamers_index
@@ -464,13 +473,9 @@ class Twitch(object):
                             ),
                             reverse=True,
                         )
-                        streamers_watching += streamers_with_multiplier[:2]
+                        streamers_watching.update(streamers_with_multiplier[:remaining_watch_amount()])
 
-                """
-                Twitch has a limit - you can't watch more than 2 channels at one time.
-                We take the first two streamers from the list as they have the highest priority (based on order or WatchStreak).
-                """
-                streamers_watching = streamers_watching[:2]
+                streamers_watching = list(streamers_watching)[:max_watch_amount]
 
                 for index in streamers_watching:
                     # next_iteration = time.time() + 60 / len(streamers_watching)


### PR DESCRIPTION
# Description

Fixes #748 

In Twitch.py `send_minute_watched_events` changes the streamer `list` to a `set` so the same streamer can't be added twice.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested locally and a couple of other users.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
