### PR TITLE
`send_minute_watched_events` Error Log Spam Reduction

### DIFF
--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -477,6 +477,8 @@ class Twitch(object):
 
                 streamers_watching = list(streamers_watching)[:max_watch_amount]
 
+                watch_attempts_start_time = time.time()
+
                 for index in streamers_watching:
                     # next_iteration = time.time() + 60 / len(streamers_watching)
                     next_iteration = time.time() + 20 / len(streamers_watching)
@@ -658,12 +660,15 @@ class Twitch(object):
                         next_iteration - time.time(), chunk_size=chunk_size
                     )
 
-                if streamers_watching == []:
-                    # self.__chuncked_sleep(60, chunk_size=chunk_size)
-                    self.__chuncked_sleep(20, chunk_size=chunk_size)
+                # Ensure we sleep at least 20 seconds, even if we `continue` iteration(s)
+                time_remaining = 20 - (time.time() - watch_attempts_start_time)
+                if len(streamers_watching) == 0 or time_remaining > 0.01:
+                    self.__chuncked_sleep(time_remaining, chunk_size=chunk_size)
             except Exception:
                 logger.error(
                     "Exception raised in send minute watched", exc_info=True)
+                # Do a short sleep to avoid error log spam
+                time.sleep(1)
 
     # === CHANNEL POINTS / PREDICTION === #
     # Load the amount of current points for a channel, check if a bonus is available


### PR DESCRIPTION
# Description

Users have reported high CPU usage and unresponsive consoles while getting error responses to `PlaybackAccessToken` requests. This PR adds sleep time between all watch attempts in `send_minute_watched_events` to avoid spamming the logger with errors.

Fixes #765 (partial)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Currently running a live test, will ask community members to test.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
