### PR TITLE
a timeout has been added for webhooks; URL encoding is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ You can use generic webhook
 | `endpoint`           | string        	   |           | webhook url                                                                                                                           |
 | `method`             | string        	   |           | The key-value pairs `event_name` and `message` are included in the body for `POST` requests or as query parameters for `GET` requests |
 | `events`   	         | list              | 	         | Only these events will be sent to the endpoint. Array of Event. or str                                                                |
-| `timeout`   	        | int               | 10	       | Timeout in seconds                                                                                                                    |
+| `timeout`   	        | int               | 1 	       | Timeout in seconds                                                                                                                    |
 
 ```python
 Webhook(

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ twitch_miner = TwitchChannelPointsMiner(
             method="GET",                                                                   # GET or POST
             events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
                     Events.BET_LOSE, Events.CHAT_MENTION],                                  # Only these events will be sent to the endpoint
+            timeout=5,
         ),
         matrix=Matrix(
             username="twitch_miner",                                                   # Matrix username (without homeserver)
@@ -530,11 +531,12 @@ Discord(
 #### Generic Webhook
 You can use generic webhook
 
-| Key                	 | Type            	| Default 	| Description                                                        |
-|----------------------- |------------------|-----------|------------------------------------------------------------------- |
-| `endpoint`             | string        	|           | webhook url                                                        |
-| `method`               | string        	|           | `POST` or `GET`                                                    |
-| `events`   	         | list             |       	| Only these events will be sent to the endpoint. Array of Event. or str |
+| Key                	 | Type            	 | Default 	 | Description                                                                                                                           |
+|----------------------|-------------------|-----------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `endpoint`           | string        	   |           | webhook url                                                                                                                           |
+| `method`             | string        	   |           | The key-value pairs `event_name` and `message` are included in the body for `POST` requests or as query parameters for `GET` requests |
+| `events`   	         | list              | 	         | Only these events will be sent to the endpoint. Array of Event. or str                                                                |
+| `timeout`   	        | int               | 10	       | Timeout in seconds                                                                                                                    |
 
 ```python
 Webhook(
@@ -542,6 +544,7 @@ Webhook(
    method="GET",
    events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
                     Events.BET_LOSE, Events.CHAT_MENTION],
+   timeout=5,
 )
 ```
 

--- a/TwitchChannelPointsMiner/classes/Webhook.py
+++ b/TwitchChannelPointsMiner/classes/Webhook.py
@@ -1,26 +1,34 @@
-from textwrap import dedent
-
 import requests
+import logging
 
 from TwitchChannelPointsMiner.classes.Settings import Events
 
+logger = logging.getLogger(__name__)
 
 class Webhook(object):
-    __slots__ = ["endpoint", "method", "events"]
+    __slots__ = ["endpoint", "method", "events", "timeout"]
 
-    def __init__(self, endpoint: str, method: str, events: list):
+    def __init__(self, endpoint: str, method: str, events: list, timeout: int = 10):
         self.endpoint = endpoint
         self.method = method
         self.events = [str(e) for e in events]
+        self.timeout = timeout
 
     def send(self, message: str, event: Events) -> None:
-        
+
         if str(event) in self.events:
-            url = self.endpoint + f"?event_name={str(event)}&message={message}" 
-            
-            if self.method.lower() == "get":
-                requests.get(url=url)
-            elif self.method.lower() == "post":
-                requests.post(url=url)
-            else:
-                raise ValueError("Invalid method, use POST or GET")
+            try:
+                url = self.endpoint
+                data = {
+                    "event_name": str(event),
+                    "message": message
+                }
+                if self.method.lower() == "get":
+                    requests.get(url=url, params=data, timeout=self.timeout)
+                elif self.method.lower() == "post":
+                    requests.post(url=url, data=data, timeout=self.timeout)
+                else:
+                    raise ValueError("Invalid method, use POST or GET")
+            except requests.exceptions.Timeout:
+                logger.error(f"Webhook timeout – {self.endpoint} did not respond within the specified timeout "
+                             f"of {str(self.timeout)} seconds")

--- a/TwitchChannelPointsMiner/classes/Webhook.py
+++ b/TwitchChannelPointsMiner/classes/Webhook.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 class Webhook(object):
     __slots__ = ["endpoint", "method", "events", "timeout"]
 
-    def __init__(self, endpoint: str, method: str, events: list, timeout: int = 10):
+    def __init__(self, endpoint: str, method: str, events: list, timeout: int = 1):
         self.endpoint = endpoint
         self.method = method
         self.events = [str(e) for e in events]

--- a/example.py
+++ b/example.py
@@ -55,11 +55,11 @@ twitch_miner = TwitchChannelPointsMiner(
                     Events.BET_LOSE, Events.CHAT_MENTION],                                  # Only these events will be sent to the chat
         ),
         webhook=Webhook(
-            endpoint="https://example.com/webhook",                                                                    # Webhook URL
-            method="GET",                                                                   # GET or POST
+            endpoint="https://example.com/webhook",                                 # Webhook URL
+            method="GET",                                                           # GET or POST
             events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
-                    Events.BET_LOSE, Events.CHAT_MENTION],                                  # Only these events will be sent to the endpoint
-            timeout=5
+                    Events.BET_LOSE, Events.CHAT_MENTION],                          # Only these events will be sent to the endpoint
+            timeout=5,                                                              # in seconds
         ),
         matrix=Matrix(
             username="twitch_miner",                                                   # Matrix username (without homeserver)

--- a/example.py
+++ b/example.py
@@ -59,6 +59,7 @@ twitch_miner = TwitchChannelPointsMiner(
             method="GET",                                                                   # GET or POST
             events=[Events.STREAMER_ONLINE, Events.STREAMER_OFFLINE,
                     Events.BET_LOSE, Events.CHAT_MENTION],                                  # Only these events will be sent to the endpoint
+            timeout=5
         ),
         matrix=Matrix(
             username="twitch_miner",                                                   # Matrix username (without homeserver)


### PR DESCRIPTION
# Description

Fixed my raised issue #805

- A timeout has been added for webhooks
  - if no timeout is defined, the default value is 10s
  - catch Timeout exception and log as error
- URL encoding is now used for GET query parameters
  - URL was not encoded; values where cut off
- POST requests with a body instead of query parameters
  - changed behavior and may break implementation of POST user

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

# How Has This Been Tested?

Good
- set up test endpoint for webhook
- start run.py with configured webhook
- encounter or trigger event
- verify result on endpoint (POST in body; GET in QUERY PARAMETERS)

Bad - times out
- set up test endpoint for webhook without HTTP response
- start run.py with configured webhook
- encounter or trigger event
- verify output in twitch miner log

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
