### PR TITLE
Fixes drops not progressing when `claim_drops` is False.

### DIFF
--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -117,12 +117,13 @@ class Twitch(object):
                 }
 
                 if (
-                    streamer.stream.game_name() is not None
-                    and streamer.stream.game_id() is not None
-                    and streamer.settings.claim_drops is True
+                        streamer.stream.game_name() is not None
+                        and streamer.stream.game_id() is not None
                 ):
                     event_properties["game"] = streamer.stream.game_name()
                     event_properties["game_id"] = streamer.stream.game_id()
+
+                if streamer.settings.claim_drops is True:
                     # Update also the campaigns_ids so we are sure to tracking the correct campaign
                     streamer.stream.campaigns_ids = (
                         self.__get_campaign_ids_from_streamer(streamer)


### PR DESCRIPTION
# Description

Fixes #811 

Thanks to @boblickj for finding the solution!

Fixes the issue of Drops not progressing when watching Streamers where `claims_drops=False`. Now, all Spade payloads will include a `game` and `game_id` regardless of that value. Twitch now seems to require these values in order to progress watch time for Drops.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested the previous version with `claim_drops=False` and saw Drops weren't progressing. Then I tested with this change and saw they did progress.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
