### PR TITLE
Handle empty persistent user id cookie

### DIFF
--- a/TwitchChannelPointsMiner/classes/TwitchLogin.py
+++ b/TwitchChannelPointsMiner/classes/TwitchLogin.py
@@ -331,10 +331,12 @@ class TwitchLogin(object):
 
     def get_user_id(self):
         persistent = self.get_cookie_value("persistent")
-        user_id = (
-            int(persistent.split("%")[
-                0]) if persistent is not None else self.user_id
-        )
+        user_id = self.user_id
+        if persistent is not None:
+            persistent_user_id = persistent.split("%", 1)[0]
+            if persistent_user_id.isdigit():
+                user_id = int(persistent_user_id)
+
         if user_id is None:
             if self.__set_user_id() is True:
                 return self.user_id


### PR DESCRIPTION
# Description

Fixes #796

This PR prevents startup crashes when Twitch provides a `persistent` cookie whose user id prefix is empty or non-numeric.

`TwitchLogin.get_user_id()` previously attempted to parse the cookie prefix with `int(...)` whenever the cookie existed. With an empty or invalid prefix this raised `ValueError` before the existing `__set_user_id()` fallback could run.

Now the cookie id is only used when the prefix is numeric. Otherwise, the method falls back to the existing user id lookup path.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Ran `python -m compileall -q TwitchChannelPointsMiner example.py setup.py`

I did not run a live Twitch session because reproducing this requires Twitch cookies/session state.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Documentation changes are not required for this change
- [x] No dependent changes were needed in requirements.txt