### PR TITLE
Reduce minute watched timeout log noise

### DIFF
--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -651,8 +651,9 @@ class Twitch(object):
                             f"Error while trying to send minute watched: {e}")
                         self.__check_connection_handler(chunk_size)
                     except requests.exceptions.Timeout as e:
-                        logger.error(
-                            f"Error while trying to send minute watched: {e}")
+                        logger.debug(
+                            f"Timed out while trying to send minute watched: {e}"
+                        )
 
                     self.__chuncked_sleep(
                         next_iteration - time.time(), chunk_size=chunk_size


### PR DESCRIPTION
# Description

Fixes #727

This PR reduces error-level log noise from transient minute-watched request timeouts.

Timeouts from the minute-watched request are retried naturally on the next watch loop, so they now log at debug level instead of error level. Connection errors still use the existing error log and reconnect path because those represent a different recovery case.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Ran `python -m compileall -q TwitchChannelPointsMiner example.py setup.py`

I did not run a live Twitch session because verifying this end-to-end requires Twitch runtime state and network behavior.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Documentation changes are not required for this change
- [x] No dependent changes were needed in requirements.txt