### PR TITLE
Update venv install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,12 +339,25 @@ twitch_miner.mine(followers=True, blacklist=["user1", "user2"])  # Blacklist exa
 ```
 
 ### By cloning the repository
-1. Clone this repository `git clone https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2`
-2. Install all the requirements `pip install -r requirements.txt` . If you have problems with requirements, make sure to have at least Python3.6. You could also try to create a _virtualenv_ and then install all the requirements
+1. Clone this repository and enter the project folder
 ```sh
-pip install virtualenv
-virtualenv -p python3 venv
+git clone https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2
+cd Twitch-Channel-Points-Miner-v2
+```
+
+2. Create and activate a virtual environment
+```sh
+python3 -m venv venv
 source venv/bin/activate
+```
+
+On Windows, activate it with:
+```powershell
+.\venv\Scripts\Activate.ps1
+```
+
+3. Install all the requirements. If you have problems with requirements, make sure to have at least Python3.6.
+```sh
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
# Description

Fixes #770

This PR updates the clone-based install instructions so users can create a virtual environment without first installing `virtualenv` into the system Python environment.

The README now uses the standard library `venv` module, adds the missing `cd Twitch-Channel-Points-Miner-v2` step before installing requirements, and lists activation commands for both POSIX shells and Windows PowerShell. This avoids the PEP 668 / externally-managed-environment failure path on distributions such as Raspberry Pi OS and current Debian-based systems.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Reviewed the updated install flow for the clone path, POSIX activation command, and Windows PowerShell activation command
- Ran `python -m compileall -q TwitchChannelPointsMiner example.py setup.py`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] No dependent changes were needed in requirements.txt