### PR TITLE
Respect SSL verification setting for Twitch requests

### DIFF
--- a/TwitchChannelPointsMiner/classes/Twitch.py
+++ b/TwitchChannelPointsMiner/classes/Twitch.py
@@ -141,13 +141,16 @@ class Twitch(object):
             headers = {"User-Agent": USER_AGENTS["Linux"]["FIREFOX"]}
 
             main_page_request = requests.get(
-                streamer.streamer_url, headers=headers)
+                streamer.streamer_url, **self.__request_options(headers=headers)
+            )
             response = main_page_request.text
             # logger.info(response)
             regex_settings = "(https://static.twitchcdn.net/config/settings.*?js|https://assets.twitch.tv/config/settings.*?.js)"
             settings_url = re.search(regex_settings, response).group(1)
 
-            settings_request = requests.get(settings_url, headers=headers)
+            settings_request = requests.get(
+                settings_url, **self.__request_options(headers=headers)
+            )
             response = settings_request.text
             regex_spade = '"spade_url":"(.*?)"'
             streamer.stream.spade_url = re.search(
@@ -273,20 +276,27 @@ class Twitch(object):
             )
             self.__chuncked_sleep(random_sleep * 60, chunk_size=chunk_size)
 
+    def __request_options(self, **kwargs):
+        if Settings.disable_ssl_cert_verification is True:
+            kwargs["verify"] = False
+        return kwargs
+
     def post_gql_request(self, json_data):
         try:
             response = requests.post(
                 GQLOperations.url,
-                json=json_data,
-                headers={
-                    "Authorization": f"OAuth {self.twitch_login.get_auth_token()}",
-                    "Client-Id": CLIENT_ID,
-                    # "Client-Integrity": self.post_integrity(),
-                    "Client-Session-Id": self.client_session,
-                    "Client-Version": self.update_client_version(),
-                    "User-Agent": self.user_agent,
-                    "X-Device-Id": self.device_id,
-                },
+                **self.__request_options(
+                    json=json_data,
+                    headers={
+                        "Authorization": f"OAuth {self.twitch_login.get_auth_token()}",
+                        "Client-Id": CLIENT_ID,
+                        # "Client-Integrity": self.post_integrity(),
+                        "Client-Session-Id": self.client_session,
+                        "Client-Version": self.update_client_version(),
+                        "User-Agent": self.user_agent,
+                        "X-Device-Id": self.device_id,
+                    },
+                ),
             )
             logger.debug(
                 f"Data: {json_data}, Status code: {response.status_code}, Content: {response.text}"
@@ -356,7 +366,7 @@ class Twitch(object):
 
     def update_client_version(self):
         try:
-            response = requests.get(URL)
+            response = requests.get(URL, **self.__request_options())
             if response.status_code != 200:
                 logger.debug(
                     f"Error with update_client_version: {response.status_code}"
@@ -532,8 +542,10 @@ class Twitch(object):
                         # Get list of video qualities
                         responseBroadcastQualities = requests.get(
                             RequestBroadcastQualitiesURL,
-                            headers={"User-Agent": self.user_agent},
-                            timeout=20,
+                            **self.__request_options(
+                                headers={"User-Agent": self.user_agent},
+                                timeout=20,
+                            ),
                         )  # timeout=60
                         logger.debug(
                             f"Send RequestBroadcastQualitiesURL request for {streamers[index]} - Status code: {responseBroadcastQualities.status_code}"
@@ -551,8 +563,10 @@ class Twitch(object):
                         # Get list of video URLs
                         responseStreamURLList = requests.get(
                             BroadcastLowestQualityURL,
-                            headers={"User-Agent": self.user_agent},
-                            timeout=20,
+                            **self.__request_options(
+                                headers={"User-Agent": self.user_agent},
+                                timeout=20,
+                            ),
                         )  # timeout=60
                         logger.debug(
                             f"Send BroadcastLowestQualityURL request for {streamers[index]} - Status code: {responseStreamURLList.status_code}"
@@ -569,8 +583,10 @@ class Twitch(object):
                         # Perform a HEAD request to simulate watching the stream
                         responseStreamLowestQualityURL = requests.head(
                             StreamLowestQualityURL,
-                            headers={"User-Agent": self.user_agent},
-                            timeout=20,
+                            **self.__request_options(
+                                headers={"User-Agent": self.user_agent},
+                                timeout=20,
+                            ),
                         )  # timeout=60
                         logger.debug(
                             f"Send StreamLowestQualityURL request for {streamers[index]} - Status code: {responseStreamLowestQualityURL.status_code}"
@@ -581,10 +597,12 @@ class Twitch(object):
                         ##################################
                         response = requests.post(
                             streamers[index].stream.spade_url,
-                            data=streamers[index].stream.encode_payload(),
-                            headers={"User-Agent": self.user_agent},
-                            # timeout=60,
-                            timeout=20,
+                            **self.__request_options(
+                                data=streamers[index].stream.encode_payload(),
+                                headers={"User-Agent": self.user_agent},
+                                # timeout=60,
+                                timeout=20,
+                            ),
                         )
                         logger.debug(
                             f"Send minute watched request for {streamers[index]} - Status code: {response.status_code}"


### PR DESCRIPTION
# Description

Related to #815

This PR makes the existing `disable_ssl_cert_verification` setting apply to Twitch watch-flow HTTP requests.

The project already exposes this setting, but several Twitch request paths still used Requests' default certificate verification unconditionally. This change routes those calls through a small helper so the setting is honored for GQL requests, Spade URL discovery, client version lookup, HLS requests, and the minute-watched Spade POST. Default SSL verification behavior is unchanged unless the existing setting is explicitly enabled.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Ran `python -m compileall -q TwitchChannelPointsMiner example.py setup.py`

I did not run a live Twitch session or proxy/certificate setup because that requires external Twitch session state and a local SSL interception/reproduction environment.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Documentation changes are not required for this change
- [x] No dependent changes were needed in requirements.txt