### PR TITLE
feat(ui): major dashboard upgrade - enhanced graphs, bet history, full config editor

### DIFF
--- a/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
+++ b/TwitchChannelPointsMiner/TwitchChannelPointsMiner.py
@@ -194,6 +194,7 @@ class TwitchChannelPointsMiner:
                 refresh=refresh,
                 days_ago=days_ago,
                 username=self.username,
+                miner=self,
             )
             http_server.daemon = True
             http_server.name = "Analytics Thread"

--- a/TwitchChannelPointsMiner/classes/AnalyticsServer.py
+++ b/TwitchChannelPointsMiner/classes/AnalyticsServer.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from collections import Counter, defaultdict
 from datetime import datetime
 from pathlib import Path
 from threading import Thread
@@ -16,11 +17,13 @@ logger = logging.getLogger(__name__)
 
 
 def streamers_available():
-    path = Settings.analytics_path
+    path = getattr(Settings, "analytics_path", None)
+    if not path or not os.path.isdir(path):
+        return []
     return [
         f
         for f in os.listdir(path)
-        if os.path.isfile(os.path.join(path, f)) and f.endswith(".json")
+        if os.path.isfile(os.path.join(path, f)) and f.endswith(".json") and f != "config.json"
     ]
 
 
@@ -41,7 +44,6 @@ def aggregate(df, freq="30Min"):
 
 
 def filter_datas(start_date, end_date, datas):
-    # Note: https://stackoverflow.com/questions/4676195/why-do-i-need-to-multiply-unix-timestamps-by-1000-in-javascript
     start_date = (
         datetime.strptime(start_date, "%Y-%m-%d").timestamp() * 1000
         if start_date is not None
@@ -53,14 +55,12 @@ def filter_datas(start_date, end_date, datas):
         else datetime.now()
     ).replace(hour=23, minute=59, second=59).timestamp() * 1000
 
-    original_series = datas["series"]
+    original_series = datas.get("series", [])
 
-    if "series" in datas:
+    if "series" in datas and datas["series"]:
         df = pd.DataFrame(datas["series"])
         df["datetime"] = pd.to_datetime(df.x // 1000, unit="s")
-
         df = df[(df.x >= start_date) & (df.x <= end_date)]
-
         datas["series"] = (
             df.drop(columns="datetime")
             .sort_values(by=["x", "y"], ascending=True)
@@ -69,35 +69,32 @@ def filter_datas(start_date, end_date, datas):
     else:
         datas["series"] = []
 
-    # If no data is found within the timeframe, that usually means the streamer hasn't streamed within that timeframe
-    # We create a series that shows up as a straight line on the dashboard, with 'No Stream' as labels
-    if len(datas["series"]) == 0:
-        new_end_date = start_date
-        new_start_date = 0
-        df = pd.DataFrame(original_series)
-        df["datetime"] = pd.to_datetime(df.x // 1000, unit="s")
+    if len(datas["series"]) == 0 and original_series:
+        try:
+            new_end_date = start_date
+            new_start_date = 0
+            df = pd.DataFrame(original_series)
+            df["datetime"] = pd.to_datetime(df.x // 1000, unit="s")
+            df = df[(df.x >= new_start_date) & (df.x <= new_end_date)]
+            if not df.empty:
+                last_balance = df.drop(columns="datetime").sort_values(
+                    by=["x", "y"], ascending=True).to_dict("records")[-1]['y']
+                datas["series"] = [{'x': start_date, 'y': last_balance, 'z': 'No Stream'}, {
+                    'x': end_date, 'y': last_balance, 'z': 'No Stream'}]
+        except Exception:
+            pass
 
-        # Attempt to get the last known balance from before the provided timeframe
-        df = df[(df.x >= new_start_date) & (df.x <= new_end_date)]
-        last_balance = df.drop(columns="datetime").sort_values(
-            by=["x", "y"], ascending=True).to_dict("records")[-1]['y']
-
-        datas["series"] = [{'x': start_date, 'y': last_balance, 'z': 'No Stream'}, {
-            'x': end_date, 'y': last_balance, 'z': 'No Stream'}]
-
-    if "annotations" in datas:
+    if "annotations" in datas and datas["annotations"]:
         df = pd.DataFrame(datas["annotations"])
         df["datetime"] = pd.to_datetime(df.x // 1000, unit="s")
-
         df = df[(df.x >= start_date) & (df.x <= end_date)]
-
         datas["annotations"] = (
             df.drop(columns="datetime")
             .sort_values(by="x", ascending=True)
             .to_dict("records")
         )
     else:
-        datas["annotations"] = []
+        datas["annotations"] = datas.get("annotations", [])
 
     return datas
 
@@ -106,10 +103,13 @@ def read_json(streamer, return_response=True):
     start_date = request.args.get("startDate", type=str)
     end_date = request.args.get("endDate", type=str)
 
-    path = Settings.analytics_path
+    path = getattr(Settings, "analytics_path", None)
+    if not path:
+        msg = "Analytics not enabled"
+        return Response(json.dumps({"error": msg}), status=500, mimetype="application/json") if return_response else {"error": msg}
+
     streamer = streamer if streamer.endswith(".json") else f"{streamer}.json"
 
-    # Check if the file exists before attempting to read it
     if not os.path.exists(os.path.join(path, streamer)):
         error_message = f"File '{streamer}' not found."
         logger.error(error_message)
@@ -129,7 +129,6 @@ def read_json(streamer, return_response=True):
         else:
             return {"error": error_message}
 
-    # Handle filtering data, if applicable
     filtered_data = filter_datas(start_date, end_date, data)
     if return_response:
         return Response(json.dumps(filtered_data), status=200, mimetype="application/json")
@@ -141,14 +140,14 @@ def get_challenge_points(streamer):
     datas = read_json(streamer, return_response=False)
     if "series" in datas and datas["series"]:
         return datas["series"][-1]["y"]
-    return 0  # Default value when 'series' key is not found or empty
+    return 0
 
 
 def get_last_activity(streamer):
     datas = read_json(streamer, return_response=False)
     if "series" in datas and datas["series"]:
         return datas["series"][-1]["x"]
-    return 0  # Default value when 'series' key is not found or empty
+    return 0
 
 
 def json_all():
@@ -187,6 +186,279 @@ def streamers():
         status=200,
         mimetype="application/json",
     )
+
+
+# === New helpers ===
+
+def get_config_path(username):
+    base = getattr(Settings, "analytics_path", None)
+    if base:
+        return os.path.join(base, "config.json")
+    # fallback to analytics/<username>/config.json
+    if username:
+        return os.path.join(Path().absolute(), "analytics", username, "config.json")
+    return os.path.join(Path().absolute(), "analytics", "config.json")
+
+
+def serialize_bet(bet):
+    if bet is None:
+        return None
+    fc = None
+    if getattr(bet, "filter_condition", None) is not None:
+        fc = bet.filter_condition
+        fc_dict = {
+            "by": str(fc.by) if fc.by else None,
+            "where": str(fc.where) if fc.where else None,
+            "value": fc.value,
+        }
+    else:
+        fc_dict = None
+    return {
+        "strategy": str(bet.strategy) if bet.strategy else None,
+        "percentage": bet.percentage,
+        "percentage_gap": bet.percentage_gap,
+        "max_points": bet.max_points,
+        "minimum_points": bet.minimum_points,
+        "stealth_mode": bet.stealth_mode,
+        "delay": bet.delay,
+        "delay_mode": str(bet.delay_mode) if bet.delay_mode else None,
+        "filter_condition": fc_dict,
+    }
+
+
+def serialize_streamer_settings(s):
+    if s is None:
+        return None
+    return {
+        "make_predictions": s.make_predictions,
+        "follow_raid": s.follow_raid,
+        "claim_drops": s.claim_drops,
+        "claim_moments": s.claim_moments,
+        "watch_streak": s.watch_streak,
+        "community_goals": s.community_goals,
+        "chat": str(s.chat) if s.chat else None,
+        "bet": serialize_bet(getattr(s, "bet", None)),
+    }
+
+
+def load_config_file(username):
+    path = get_config_path(username)
+    if os.path.isfile(path):
+        try:
+            with open(path, "r") as f:
+                return json.load(f)
+        except Exception as e:
+            logger.error(f"Failed to load config {path}: {e}")
+    return None
+
+
+def save_config_file(username, data):
+    path = get_config_path(username)
+    Path(os.path.dirname(path)).mkdir(parents=True, exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(data, f, indent=4)
+    os.replace(tmp, path)
+    return path
+
+
+def default_global_config():
+    # Settings uses __slots__ - getattr returns member_descriptor when not set, so check for real instance
+    try:
+        gs = getattr(Settings, "streamer_settings", None)
+        # member_descriptor has no make_predictions attr, real settings does
+        if gs is not None and hasattr(gs, "make_predictions"):
+            return serialize_streamer_settings(gs)
+    except Exception:
+        pass
+    # fallback defaults
+    return {
+        "make_predictions": True,
+        "follow_raid": True,
+        "claim_drops": True,
+        "claim_moments": True,
+        "watch_streak": True,
+        "community_goals": False,
+        "chat": "ONLINE",
+        "bet": {
+            "strategy": "SMART",
+            "percentage": 5,
+            "percentage_gap": 20,
+            "max_points": 50000,
+            "minimum_points": 0,
+            "stealth_mode": False,
+            "delay": 6,
+            "delay_mode": "FROM_END",
+            "filter_condition": None,
+        },
+    }
+
+
+def compute_streamer_stats(streamer_file, username=None):
+    # streamer_file is like "feinberg.json"
+    path = getattr(Settings, "analytics_path", None)
+    if not path:
+        if username:
+            path = os.path.join(Path().absolute(), "analytics", username)
+        else:
+            return {}
+    full = os.path.join(path, streamer_file)
+    if not os.path.isfile(full):
+        return {}
+    try:
+        with open(full, "r") as f:
+            data = json.load(f)
+    except Exception:
+        return {}
+
+    series = data.get("series", [])
+    annotations = data.get("annotations", [])
+
+    if not series:
+        return {"points": 0, "last_activity": 0, "total_gained": 0, "series_count": 0, "bets": {"placed": 0, "wins": 0, "losses": 0, "win_rate": 0}}
+
+    points = series[-1].get("y", 0)
+    last_activity = series[-1].get("x", 0)
+    first_y = series[0].get("y", points)
+    total_gained = points - first_y
+
+    # Gains by reason
+    z_counter = Counter([s.get("z", "Unknown") for s in series])
+    # gains per reason approximated by diffs? Use count and sum of deltas per reason
+    gains_by_reason = defaultdict(int)
+    # compute delta between consecutive points and attribute to current reason
+    for i in range(1, len(series)):
+        delta = series[i]["y"] - series[i-1]["y"]
+        if delta > 0:
+            reason = series[i].get("z", "Unknown")
+            gains_by_reason[reason] += delta
+
+    # Bet stats from annotations: colors
+    # #45c1ff streak, #ffe045 prediction_made, #36b535 win, #ff4545 lose
+    color_map = {"#45c1ff": 0, "#ffe045": 0, "#36b535": 0, "#ff4545": 0}
+    for a in annotations:
+        c = a.get("borderColor")
+        if c in color_map:
+            color_map[c] += 1
+
+    placed = color_map["#ffe045"]
+    wins = color_map["#36b535"]
+    losses = color_map["#ff4545"]
+    streaks = color_map["#45c1ff"]
+    win_rate = round((wins / (wins + losses) * 100) if (wins + losses) > 0 else 0, 1)
+
+    # history table similar to Streamer.history: aggregate gains_by_reason
+    history = {k: {"counter": z_counter.get(k, 0), "amount": gains_by_reason.get(k, 0)} for k in set(list(z_counter.keys()) + list(gains_by_reason.keys()))}
+
+    return {
+        "name": streamer_file.replace(".json", ""),
+        "file": streamer_file,
+        "points": points,
+        "last_activity": last_activity,
+        "first_y": first_y,
+        "total_gained": total_gained,
+        "series_count": len(series),
+        "annotations_count": len(annotations),
+        "z_counter": dict(z_counter),
+        "gains_by_reason": dict(gains_by_reason),
+        "history": history,
+        "bets": {
+            "placed": placed,
+            "wins": wins,
+            "losses": losses,
+            "streaks": streaks,
+            "win_rate": win_rate,
+        },
+    }
+
+
+def api_overview(username):
+    files = streamers_available()
+    stats_list = [compute_streamer_stats(f, username) for f in files]
+    total_points = sum(s.get("points", 0) for s in stats_list)
+    total_gained = sum(s.get("total_gained", 0) for s in stats_list)
+    total_bets = sum(s.get("bets", {}).get("placed", 0) for s in stats_list)
+    total_wins = sum(s.get("bets", {}).get("wins", 0) for s in stats_list)
+    total_losses = sum(s.get("bets", {}).get("losses", 0) for s in stats_list)
+    # top streamer by points
+    top = max(stats_list, key=lambda x: x.get("points", 0)) if stats_list else None
+    return {
+        "total_streamers": len(files),
+        "total_points": total_points,
+        "total_gained": total_gained,
+        "total_bets": total_bets,
+        "total_wins": total_wins,
+        "total_losses": total_losses,
+        "win_rate": round((total_wins / (total_wins + total_losses) * 100) if (total_wins + total_losses) > 0 else 0, 1),
+        "top_streamer": top.get("name") if top else None,
+        "streamers": stats_list,
+    }
+
+
+def api_bet_history(username, streamer=None):
+    path = getattr(Settings, "analytics_path", None)
+    if not path and username:
+        path = os.path.join(Path().absolute(), "analytics", username)
+    files = [streamer + ".json"] if streamer else streamers_available()
+    rows = []
+    for fname in files:
+        full = os.path.join(path, fname) if path else fname
+        if not os.path.isfile(full):
+            continue
+        try:
+            with open(full, "r") as f:
+                data = json.load(f)
+        except Exception:
+            continue
+        name = fname.replace(".json", "")
+        annotations = data.get("annotations", [])
+        series = data.get("series", [])
+        # series dict for quick lookup of balance at time
+        for ann in annotations:
+            color = ann.get("borderColor")
+            text = ann.get("label", {}).get("text", "")
+            x = ann.get("x", 0)
+            # map color to type
+            if color == "#ffe045":
+                typ = "BET_PLACED"
+            elif color == "#36b535":
+                typ = "WIN"
+            elif color == "#ff4545":
+                typ = "LOSE"
+            elif color == "#45c1ff":
+                typ = "WATCH_STREAK"
+            else:
+                typ = "OTHER"
+            # find balance at x (nearest series before)
+            balance = None
+            for s in reversed(series):
+                if s["x"] <= x:
+                    balance = s["y"]
+                    break
+            rows.append({
+                "streamer": name,
+                "type": typ,
+                "color": color,
+                "text": text,
+                "x": x,
+                "datetime": datetime.fromtimestamp(x/1000).isoformat() if x else None,
+                "balance": balance,
+            })
+    # sort by time desc
+    rows.sort(key=lambda r: r["x"], reverse=True)
+    return rows
+
+
+def api_enums():
+    # expose allowed enum values for frontend
+    return {
+        "strategies": ["MOST_VOTED", "HIGH_ODDS", "PERCENTAGE", "SMART_MONEY", "SMART", "NUMBER_1", "NUMBER_2", "NUMBER_3", "NUMBER_4", "NUMBER_5", "NUMBER_6", "NUMBER_7", "NUMBER_8"],
+        "delay_modes": ["FROM_START", "FROM_END", "PERCENTAGE"],
+        "chat_presences": ["ALWAYS", "NEVER", "ONLINE", "OFFLINE"],
+        "outcome_keys": ["PERCENTAGE_USERS", "ODDS_PERCENTAGE", "ODDS", "TOP_POINTS", "TOTAL_USERS", "TOTAL_POINTS", "DECISION_USERS", "DECISION_POINTS"],
+        "conditions": ["GT", "LT", "GTE", "LTE"],
+        "priorities": ["STREAK", "DROPS", "ORDER", "SUBSCRIBED", "POINTS_ASCENDING", "POINTS_DESCENDING"],
+    }
 
 
 def download_assets(assets_folder, required_files):
@@ -231,7 +503,8 @@ class AnalyticsServer(Thread):
         port: int = 5000,
         refresh: int = 5,
         days_ago: int = 7,
-        username: str = None
+        username: str = None,
+        miner=None,
     ):
         super(AnalyticsServer, self).__init__()
 
@@ -242,27 +515,244 @@ class AnalyticsServer(Thread):
         self.refresh = refresh
         self.days_ago = days_ago
         self.username = username
+        self.miner = miner
 
         def generate_log():
-            global last_sent_log_index  # Use the global variable
-
-            # Get the last received log index from the client request parameters
+            global last_sent_log_index
             last_received_index = int(request.args.get("lastIndex", last_sent_log_index))
-
             logs_path = os.path.join(Path().absolute(), "logs")
             log_file_path = os.path.join(logs_path, f"{username}.log")
             try:
                 with open(log_file_path, "r", encoding="utf-8") as log_file:
                     log_content = log_file.read()
-
-                # Extract new log entries since the last received index
                 new_log_entries = log_content[last_received_index:]
-                last_sent_log_index = len(log_content)  # Update the last sent index
-
+                last_sent_log_index = len(log_content)
                 return Response(new_log_entries, status=200, mimetype="text/plain")
-
             except FileNotFoundError:
                 return Response("Log file not found.", status=404, mimetype="text/plain")
+
+        # === API handlers (closures capturing username/miner) ===
+        def api_config_get():
+            saved = load_config_file(username)
+            if saved:
+                return Response(json.dumps(saved), status=200, mimetype="application/json")
+            live_global = default_global_config()
+            streamers_cfg = {}
+            if self.miner and hasattr(self.miner, "streamers"):
+                for s in self.miner.streamers:
+                    if hasattr(s, "settings") and s.settings:
+                        streamers_cfg[s.username] = serialize_streamer_settings(s.settings)
+            out = {"global": live_global, "streamers": streamers_cfg, "priority": [str(p) for p in getattr(self.miner, "priority", [])] if self.miner and hasattr(self.miner, "priority") else []}
+            return Response(json.dumps(out), status=200, mimetype="application/json")
+
+        def api_config_put():
+            try:
+                data = request.get_json(force=True)
+            except Exception as e:
+                return Response(json.dumps({"error": str(e)}), status=400, mimetype="application/json")
+            # merge with existing or create new
+            existing = load_config_file(username) or {"global": default_global_config(), "streamers": {}, "priority": []}
+            if "global" in data:
+                existing["global"] = data["global"]
+                # also try to apply to live Settings if miner running
+                try:
+                    from TwitchChannelPointsMiner.classes.entities.Bet import Strategy, DelayMode, FilterCondition, BetSettings, Condition, OutcomeKeys
+                    from TwitchChannelPointsMiner.classes.Chat import ChatPresence
+                    from TwitchChannelPointsMiner.classes.entities.Streamer import StreamerSettings
+                    gs = existing["global"]
+                    # update Settings.streamer_settings live (best effort) - guard for __slots__ descriptor
+                    try:
+                        _live_tmp = getattr(Settings, "streamer_settings", None)
+                        live = _live_tmp if _live_tmp is not None and hasattr(_live_tmp, "make_predictions") else None
+                    except Exception:
+                        live = None
+                    if live:
+                        for k in ["make_predictions","follow_raid","claim_drops","claim_moments","watch_streak","community_goals"]:
+                            if k in gs:
+                                setattr(live, k, gs[k])
+                        if "chat" in gs and gs["chat"]:
+                            try:
+                                setattr(live, "chat", ChatPresence[gs["chat"]])
+                            except: pass
+                        if "bet" in gs and gs["bet"]:
+                            b = gs["bet"]
+                            blive = live.bet
+                            for kb in ["percentage","percentage_gap","max_points","minimum_points","stealth_mode","delay"]:
+                                if kb in b:
+                                    setattr(blive, kb, b[kb])
+                            if "strategy" in b and b["strategy"]:
+                                try: blive.strategy = Strategy[b["strategy"]]
+                                except: pass
+                            if "delay_mode" in b and b["delay_mode"]:
+                                try: blive.delay_mode = DelayMode[b["delay_mode"]]
+                                except: pass
+                            if "filter_condition" in b:
+                                fc = b["filter_condition"]
+                                if fc is None:
+                                    blive.filter_condition = None
+                                else:
+                                    try:
+                                        blive.filter_condition = FilterCondition(by=OutcomeKeys[fc["by"]] if fc.get("by") else None, where=Condition[fc["where"]] if fc.get("where") else None, value=fc.get("value"))
+                                        # Normalize by to string value for storage
+                                        blive.filter_condition.by = fc.get("by")
+                                        blive.filter_condition.where = fc.get("where")
+                                        blive.filter_condition.value = fc.get("value")
+                                    except: pass
+                except Exception as e:
+                    logger.error(f"Failed to apply live config: {e}")
+            if "streamers" in data:
+                existing["streamers"] = data["streamers"]
+            if "priority" in data:
+                existing["priority"] = data["priority"]
+            save_config_file(username, existing)
+            return Response(json.dumps({"status": "ok", "config": existing}), status=200, mimetype="application/json")
+
+        def api_streamer_put(name):
+            try:
+                data = request.get_json(force=True)
+            except Exception as e:
+                return Response(json.dumps({"error": str(e)}), status=400, mimetype="application/json")
+            cfg = load_config_file(username) or {"global": default_global_config(), "streamers": {}, "priority": []}
+            if "streamers" not in cfg:
+                cfg["streamers"] = {}
+            cfg["streamers"][name] = data
+            # attempt live update if miner has this streamer
+            if self.miner and hasattr(self.miner, "streamers"):
+                for s in self.miner.streamers:
+                    if s.username == name.lower():
+                        try:
+                            from TwitchChannelPointsMiner.classes.entities.Bet import Strategy, DelayMode, FilterCondition, BetSettings, Condition, OutcomeKeys
+                            from TwitchChannelPointsMiner.classes.Chat import ChatPresence
+                            from TwitchChannelPointsMiner.classes.entities.Streamer import StreamerSettings
+                            # shallow apply
+                            for k in ["make_predictions","follow_raid","claim_drops","claim_moments","watch_streak","community_goals"]:
+                                if k in data:
+                                    setattr(s.settings, k, data[k])
+                            if "chat" in data and data["chat"]:
+                                try: s.settings.chat = ChatPresence[data["chat"]]
+                                except: pass
+                            if "bet" in data and data["bet"]:
+                                b=data["bet"]
+                                blive=s.settings.bet
+                                if blive is None:
+                                    blive=BetSettings()
+                                    s.settings.bet=blive
+                                for kb in ["percentage","percentage_gap","max_points","minimum_points","stealth_mode","delay"]:
+                                    if kb in b:
+                                        setattr(blive, kb, b[kb])
+                                if "strategy" in b and b["strategy"]:
+                                    try: blive.strategy = Strategy[b["strategy"]]
+                                    except: pass
+                                if "delay_mode" in b and b["delay_mode"]:
+                                    try: blive.delay_mode = DelayMode[b["delay_mode"]]
+                                    except: pass
+                                if "filter_condition" in b:
+                                    fc=b["filter_condition"]
+                                    if fc is None:
+                                        blive.filter_condition=None
+                                    else:
+                                        try:
+                                            # store as object but keep raw strings
+                                            cond = FilterCondition(by=fc.get("by"), where=fc.get("where"), value=fc.get("value"))
+                                            # fix by/where to enum for runtime if possible
+                                            try:
+                                                cond.by = OutcomeKeys[fc["by"]] if fc.get("by") and hasattr(OutcomeKeys, fc["by"]) else fc.get("by")
+                                            except: pass
+                                            try:
+                                                cond.where = Condition[fc["where"]] if fc.get("where") and hasattr(Condition, fc["where"]) else fc.get("where")
+                                            except: pass
+                                            blive.filter_condition=cond
+                                        except: pass
+                        except Exception as e:
+                            logger.error(f"live update failed for {name}: {e}")
+            save_config_file(username, cfg)
+            return Response(json.dumps({"status": "ok", "streamer": name, "settings": data}), status=200, mimetype="application/json")
+
+        def api_streamer_delete(name):
+            cfg = load_config_file(username) or {"global": default_global_config(), "streamers": {}, "priority": []}
+            if name in cfg.get("streamers", {}):
+                del cfg["streamers"][name]
+                save_config_file(username, cfg)
+                return Response(json.dumps({"status": "deleted", "streamer": name}), status=200, mimetype="application/json")
+            return Response(json.dumps({"error": "not found"}), status=404, mimetype="application/json")
+
+        def api_streamer_add():
+            try:
+                data = request.get_json(force=True)
+            except Exception as e:
+                return Response(json.dumps({"error": str(e)}), status=400, mimetype="application/json")
+            name = data.get("username") or data.get("name")
+            if not name:
+                return Response(json.dumps({"error": "username required"}), status=400, mimetype="application/json")
+            name = name.lower().strip()
+            settings = data.get("settings")
+            cfg = load_config_file(username) or {"global": default_global_config(), "streamers": {}, "priority": []}
+            if cfg["streamers"].get(name):
+                return Response(json.dumps({"error": "already exists"}), status=409, mimetype="application/json")
+            cfg["streamers"][name] = settings if settings else None
+            save_config_file(username, cfg)
+            return Response(json.dumps({"status": "created", "streamer": name}), status=201, mimetype="application/json")
+
+        def api_overview_handler():
+            data = api_overview(username)
+            return Response(json.dumps(data), status=200, mimetype="application/json")
+
+        def api_bets_handler():
+            streamer = request.args.get("streamer", type=str)
+            limit = request.args.get("limit", type=int) or 100
+            type_filter = request.args.get("type", type=str)
+            rows = api_bet_history(username, streamer)
+            if type_filter:
+                rows = [r for r in rows if r["type"] == type_filter.upper()]
+            rows = rows[:limit]
+            return Response(json.dumps(rows), status=200, mimetype="application/json")
+
+        def api_streamers_details():
+            files = streamers_available()
+            out = []
+            for f in files:
+                stats = compute_streamer_stats(f, username)
+                # merge with config if exists
+                cfg = load_config_file(username)
+                per_stream_cfg = None
+                if cfg and "streamers" in cfg:
+                    per_stream_cfg = cfg["streamers"].get(stats["name"]) or cfg["streamers"].get(stats["name"].lower())
+                stats["config"] = per_stream_cfg
+                # live online status if miner available
+                if self.miner and hasattr(self.miner, "streamers"):
+                    for s in self.miner.streamers:
+                        if s.username == stats["name"].lower():
+                            stats["is_online"] = s.is_online
+                            stats["channel_points_live"] = s.channel_points
+                            break
+                out.append(stats)
+            # sort by points desc by default
+            out.sort(key=lambda x: x.get("points", 0), reverse=True)
+            return Response(json.dumps(out), status=200, mimetype="application/json")
+
+        def api_enums_handler():
+            return Response(json.dumps(api_enums()), status=200, mimetype="application/json")
+
+        def api_series_aggregate(streamer):
+            freq = request.args.get("freq", type=str) or "30Min"
+            data = read_json(streamer, return_response=False)
+            if "error" in data:
+                return Response(json.dumps(data), status=404, mimetype="application/json")
+            if freq != "raw" and "series" in data and data["series"]:
+                try:
+                    df = pd.DataFrame(data["series"])
+                    df["datetime"] = pd.to_datetime(df.x // 1000, unit="s")
+                    agg = aggregate(df, freq=freq)
+                    # agg is DataFrame with datetime and z groups
+                    # Convert back to series format: need x,y,z
+                    # agg has columns datetime,z,y,x maybe max aggregation - use max y per group
+                    # Simplify: group by z and datetime
+                    # agg already contains x,y?
+                    # For simplicity, return filtered data without aggregation if aggregation fails
+                    data["series"] = agg.drop(columns="datetime").sort_values(by=["x","y"]).to_dict("records") if "x" in agg else data["series"]
+                except Exception as e:
+                    logger.error(f"aggregate failed: {e}")
+            return Response(json.dumps(data), status=200, mimetype="application/json")
 
         self.app = Flask(
             __name__,
@@ -285,6 +775,17 @@ class AnalyticsServer(Thread):
                               json_all, methods=["GET"])
         self.app.add_url_rule(
             "/log", "log", generate_log, methods=["GET"])
+        # New APIs
+        self.app.add_url_rule("/api/config", "api_config_get", api_config_get, methods=["GET"])
+        self.app.add_url_rule("/api/config", "api_config_put", api_config_put, methods=["PUT"])
+        self.app.add_url_rule("/api/config/streamer/<string:name>", "api_streamer_put", api_streamer_put, methods=["PUT"])
+        self.app.add_url_rule("/api/config/streamer/<string:name>", "api_streamer_delete", api_streamer_delete, methods=["DELETE"])
+        self.app.add_url_rule("/api/config/streamer", "api_streamer_add", api_streamer_add, methods=["POST"])
+        self.app.add_url_rule("/api/overview", "api_overview", api_overview_handler, methods=["GET"])
+        self.app.add_url_rule("/api/bets", "api_bets", api_bets_handler, methods=["GET"])
+        self.app.add_url_rule("/api/streamers/details", "api_streamers_details", api_streamers_details, methods=["GET"])
+        self.app.add_url_rule("/api/enums", "api_enums", api_enums_handler, methods=["GET"])
+        self.app.add_url_rule("/api/series/<string:streamer>", "api_series_agg", api_series_aggregate, methods=["GET"])
 
     def run(self):
         logger.info(

--- a/assets/charts.html
+++ b/assets/charts.html
@@ -1,209 +1,197 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Twitch-Channel-Points-Miner-v2</title>
-    <link rel="icon" type="image/png" sizes="32x32"
-        href="https://static.twitchcdn.net/assets/favicon-32-e29e246c157142c94346.png">
-    <link rel="icon" type="image/png" sizes="16x16"
-        href="https://static.twitchcdn.net/assets/favicon-16-52e571ffea063af7a7f4.png">
-
+    <link rel="icon" type="image/png" sizes="32x32" href="https://static.twitchcdn.net/assets/favicon-32-e29e246c157142c94346.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="https://static.twitchcdn.net/assets/favicon-16-52e571ffea063af7a7f4.png">
     <script src="https://cdn.jsdelivr.net/npm/apexcharts@3.42.0"></script>
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.min.js"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.6.1/css/bulma.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet"
-        integrity="sha512-1ycn6IcaQQ40/MKBW2W4Rhis/DbILU74C1vSrLJxCq57o941Ym01SwNsOMqvEBFlcgUa6xLiPY/NS5R+E6ztJQ=="
-        crossorigin="anonymous" referrerpolicy="no-referrer" />
-
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />
     <link href="{{url_for('static', filename='dark-theme.css')}}" rel="stylesheet" />
     <link href="{{url_for('static', filename='style.css')}}" rel="stylesheet" />
-
 </head>
-
-<body style="height: 100vh;">
-    <div class="container has-text-centered" style="height: 100vh;">
-        <div class="columns" id="header">
-            <div class="column has-text-right">
-                <a href="https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2" target="_blank"><img
-                        style="margin-top: -20px;" width="600px" src="{{url_for('static', filename='banner.png')}}"
-                        alt="banner"></a>
+<body>
+    <nav class="topbar" id="header">
+        <div class="topbar-left">
+            <a href="https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2" target="_blank"><img width="420" src="{{url_for('static', filename='banner.png')}}" alt="banner"></a>
+        </div>
+        <div class="topbar-right">
+            <div class="header-stats" id="overview-stats">
+                <span class="stat" title="Total streamers"><i class="fa-solid fa-users"></i> <b id="stat-streamers">-</b> streamers</span>
+                <span class="stat" title="Total points"><i class="fa-solid fa-coins"></i> <b id="stat-points">-</b></span>
+                <span class="stat" title="Total gained"><i class="fa-solid fa-arrow-trend-up"></i> +<b id="stat-gained">-</b></span>
+                <span class="stat" title="Win rate"><i class="fa-solid fa-trophy"></i> <b id="stat-winrate">-</b>% WR</span>
             </div>
-            <div class="column is-4 has-text-left" style="margin-top: 35px;">
-                <table>
-                    <tr>
-                        <td><a href="https://github.com/Tkd-Alex" target="_blank">Tkd-Alex</a></td>
-                        <td><a href="https://github.com/rdavydov" target="_blank">rdavydov</a></td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/blob/master/LICENSE">
-                                <img alt="License"
-                                    src="https://img.shields.io/github/license/Tkd-Alex/Twitch-Channel-Points-Miner-v2" /></a>
-                        </td>
-                        <td><a href="https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/blob/master/LICENSE">
-                                <img alt="License"
-                                    src="https://img.shields.io/github/license/rdavydov/Twitch-Channel-Points-Miner-v2" /></a>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://www.python.org/downloads/release/python-360/">
-                                <img alt="Python3"
-                                    src="https://img.shields.io/badge/built%20for-Python≥3.6-red.svg?style=flat"></a>
-                        </td>
-                        <td><a href="https://www.python.org/downloads/release/python-360/">
-                                <img alt="Python3"
-                                    src="https://img.shields.io/badge/built%20for-Python≥3.6-red.svg?style=flat"></a>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/pulls">
-                                <img alt="PRsWelcome"
-                                    src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat" /></a>
-                        </td>
-                        <td><a href="https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/pulls">
-                                <img alt="PRsWelcome"
-                                    src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat" /></a>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/stargazers">
-                                <img alt="GitHub Repo stars"
-                                    src="https://img.shields.io/github/stars/Tkd-Alex/Twitch-Channel-Points-Miner-v2" /></a>
-                        </td>
-                        <td><a href="https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/stargazers">
-                                <img alt="GitHub Repo stars"
-                                    src="https://img.shields.io/github/stars/rdavydov/Twitch-Channel-Points-Miner-v2" /></a>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td><a
-                                href="https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2/issues?q=is%3Aissue+is%3Aclosed">
-                                <img alt="GitHub closed issues"
-                                    src="https://img.shields.io/github/issues-closed/Tkd-Alex/Twitch-Channel-Points-Miner-v2"></a>
-                        </td>
-                        <td><a
-                                href="https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2/issues?q=is%3Aissue+is%3Aclosed">
-                                <img alt="GitHub closed issues"
-                                    src="https://img.shields.io/github/issues-closed/rdavydov/Twitch-Channel-Points-Miner-v2"></a>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td><a href="https://github.com/Tkd-Alex/Twitch-Channel-Points-Miner-v2">
-                                <img alt="GitHub last commit"
-                                    src="https://img.shields.io/github/last-commit/Tkd-Alex/Twitch-Channel-Points-Miner-v2" /></a>
-                        </td>
-                        <td><a href="https://github.com/rdavydov/Twitch-Channel-Points-Miner-v2">
-                                <img alt="GitHub last commit"
-                                    src="https://img.shields.io/github/last-commit/rdavydov/Twitch-Channel-Points-Miner-v2" /></a>
-                        </td>
-                    </tr>
-                </table>
+            <div class="topbar-actions">
+                <label class="toggle"><input type="checkbox" checked id="dark-mode"> Dark</label>
+                <label class="toggle"><input type="checkbox" checked id="toggle-header"> Header</label>
+                <a href="/logs" class="btn-small" target="_blank"><i class="fa-solid fa-file-lines"></i> Logs</a>
             </div>
         </div>
+    </nav>
 
-        <div class="columns">
-            <div class="column is-narrow has-text-center">
-                <div class="dropdown">
-                    <div class="dropdown-trigger">
-                        <button class="button" aria-haspopup="true" aria-controls="dropdown-menu">
-                            <span id="sorting-by"></span>
-                            <span class="icon is-small">
-                                <i class="fas fa-angle-down" aria-hidden="true"></i>
-                            </span>
-                        </button>
-                    </div>
+    <div class="tabs-nav">
+        <button class="tab-btn active" data-tab="dashboard"><i class="fa-solid fa-chart-line"></i> Dashboard</button>
+        <button class="tab-btn" data-tab="history"><i class="fa-solid fa-clock-rotate-left"></i> Bet History</button>
+        <button class="tab-btn" data-tab="config"><i class="fa-solid fa-gear"></i> Config</button>
+    </div>
+
+    <!-- DASHBOARD TAB -->
+    <div id="tab-dashboard" class="tab-pane active">
+        <div class="controls-bar">
+            <div class="control-group">
+                <div class="dropdown" id="sort-dropdown">
+                    <button class="button" aria-haspopup="true"><span id="sorting-by">Name ascending</span> <i class="fa-solid fa-angle-down"></i></button>
                     <div class="dropdown-menu" id="dropdown-menu" role="menu">
                         <div class="dropdown-content">
-                            <a href="#" class="dropdown-item" onClick="changeSortBy(this)">
-                                Name ascending
-                            </a>
-                            <a href="#" class="dropdown-item" onClick="changeSortBy(this)">
-                                Name descending
-                            </a>
-                            <a href="#" class="dropdown-item" onClick="changeSortBy(this)">
-                                Points ascending
-                            </a>
-                            <a href="#" class="dropdown-item" onClick="changeSortBy(this)">
-                                Points descending
-                            </a>
-                            <a href="#" class="dropdown-item" onClick="changeSortBy(this)">
-                                Last activity ascending
-                            </a>
-                            <a href="#" class="dropdown-item" onClick="changeSortBy(this)">
-                                Last activity descending
-                            </a>
+                            <a href="#" class="dropdown-item" onClick="changeSortBy(this)">Name ascending</a>
+                            <a href="#" class="dropdown-item" onClick="changeSortBy(this)">Name descending</a>
+                            <a href="#" class="dropdown-item" onClick="changeSortBy(this)">Points ascending</a>
+                            <a href="#" class="dropdown-item" onClick="changeSortBy(this)">Points descending</a>
+                            <a href="#" class="dropdown-item" onClick="changeSortBy(this)">Gained ascending</a>
+                            <a href="#" class="dropdown-item" onClick="changeSortBy(this)">Gained descending</a>
+                            <a href="#" class="dropdown-item" onClick="changeSortBy(this)">Last activity ascending</a>
+                            <a href="#" class="dropdown-item" onClick="changeSortBy(this)">Last activity descending</a>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class="column is-2 has-text-left">
-                <input class="input" type="date" id="startDate">
-            </div>
-            <div class="column is-2 has-text-left">
-                <input class="input" type="date" id="endDate">
-            </div>
-            <div class="column has-text-right" style="margin: auto">
-                <button id="auto-update-log">⏸️</button>
-                <label class="checkbox checkbox-label">
-                    Log
-                    <input type="checkbox" id="log">
-                </label>
-                <label class="checkbox checkbox-label">
-                    Annotations
-                    <input type="checkbox" checked="true" id="annotations">
-                </label>
-                <label class="checkbox checkbox-label">
-                    Dark mode
-                    <input type="checkbox" checked="true" id="dark-mode">
-                </label>
-                <label class="checkbox checkbox-label">
-                    Header
-                    <input type="checkbox" checked="true" id="toggle-header">
-                </label>
-            </div>
-        </div>
-        <div class="columns">
-            <div class="column is-narrow">
-                <div class="tabs">
-                    <ul id="streamers-list"></ul>
+                <div class="search-box">
+                    <i class="fa-solid fa-magnifying-glass"></i>
+                    <input type="text" id="streamer-search" placeholder="Filter streamers..." autocomplete="off">
                 </div>
             </div>
-            <div class="column">
-                <div class="box" id="chart" style="padding: 0.30rem;"></div>
+            <div class="control-group">
+                <div class="preset-group">
+                    <button class="preset-btn active" data-days="7">7D</button>
+                    <button class="preset-btn" data-days="30">30D</button>
+                    <button class="preset-btn" data-days="90">90D</button>
+                    <button class="preset-btn" data-days="all">All</button>
+                </div>
+                <input class="input date-input" type="date" id="startDate">
+                <input class="input date-input" type="date" id="endDate">
+                <select id="agg-select" class="input" title="Aggregation">
+                    <option value="raw">Raw</option>
+                    <option value="30Min" selected>30 min</option>
+                    <option value="1H">1 hour</option>
+                    <option value="6H">6 hours</option>
+                    <option value="1D">1 day</option>
+                </select>
+            </div>
+            <div class="control-group right">
+                <label class="toggle"><input type="checkbox" id="compare-mode"> Compare</label>
+                <label class="toggle"><input type="checkbox" checked id="annotations"> Annotations</label>
+                <button class="btn-small" id="btn-export" title="Export CSV"><i class="fa-solid fa-download"></i> Export</button>
+                <button class="btn-small" id="btn-reset-zoom"><i class="fa-solid fa-magnifying-glass-minus"></i> Reset zoom</button>
+                <label class="toggle"><input type="checkbox" id="log"> Log</label>
             </div>
         </div>
-        <div class="columns">
-            <div class="column is-12">
-                <div class="box" id="log-box" style="padding: 0.30rem; display: none;">
-                    <pre id="log-content">In your run.py file set save=True in logger_settings to save logs to a file.&#10;&#13;</pre>
+
+        <div class="dashboard-grid">
+            <aside class="streamers-panel">
+                <div class="panel-header">
+                    <span>Streamers</span>
+                    <span class="badge" id="streamer-count">0</span>
                 </div>
+                <ul id="streamers-list" class="streamers-list"></ul>
+            </aside>
+            <main class="chart-panel">
+                <div class="chart-header">
+                    <h2 id="chart-title">Select a streamer</h2>
+                    <div class="chart-stats" id="chart-stats"></div>
+                </div>
+                <div class="box" id="chart"></div>
+                <div class="gain-breakdown" id="gain-breakdown"></div>
+                <div class="box" id="log-box" style="display:none;">
+                    <div class="box-header">Live Log <button id="auto-update-log" title="Pause/Resume">⏸️</button></div>
+                    <pre id="log-content">In your run.py file set save=True in logger_settings to save logs to a file.</pre>
+                </div>
+            </main>
+        </div>
+    </div>
+
+    <!-- HISTORY TAB -->
+    <div id="tab-history" class="tab-pane">
+        <div class="history-controls">
+            <div class="control-group">
+                <select id="history-streamer-filter" class="input"><option value="">All streamers</option></select>
+                <select id="history-type-filter" class="input">
+                    <option value="">All types</option>
+                    <option value="WIN">Wins</option>
+                    <option value="LOSE">Losses</option>
+                    <option value="BET_PLACED">Bets placed</option>
+                    <option value="WATCH_STREAK">Watch streaks</option>
+                </select>
+                <input type="text" id="history-search" class="input" placeholder="Search text...">
+                <button class="btn-small" id="btn-history-refresh"><i class="fa-solid fa-rotate"></i> Refresh</button>
+            </div>
+            <div class="history-summary" id="history-summary"></div>
+        </div>
+        <div class="table-wrapper">
+            <table class="history-table">
+                <thead>
+                    <tr>
+                        <th data-sort="datetime">Time <i class="fa-solid fa-sort"></i></th>
+                        <th data-sort="streamer">Streamer <i class="fa-solid fa-sort"></i></th>
+                        <th data-sort="type">Type <i class="fa-solid fa-sort"></i></th>
+                        <th>Details</th>
+                        <th data-sort="balance">Balance <i class="fa-solid fa-sort"></i></th>
+                    </tr>
+                </thead>
+                <tbody id="history-body"><tr><td colspan="5" class="empty">Loading...</td></tr></tbody>
+            </table>
+        </div>
+        <div class="pagination" id="history-pagination"></div>
+    </div>
+
+    <!-- CONFIG TAB -->
+    <div id="tab-config" class="tab-pane">
+        <div class="config-layout">
+            <div class="config-card">
+                <h3><i class="fa-solid fa-globe"></i> Global Settings <span class="subtitle">Applied to all streamers unless overridden</span></h3>
+                <div id="global-config-form"></div>
+                <div class="form-actions">
+                    <button class="btn-primary" id="btn-save-global"><i class="fa-solid fa-floppy-disk"></i> Save Global Settings</button>
+                    <span id="global-save-status" class="save-status"></span>
+                </div>
+            </div>
+            <div class="config-card">
+                <div class="card-header-row">
+                    <h3><i class="fa-solid fa-users-gear"></i> Per-Channel Settings</h3>
+                    <div class="add-streamer-row">
+                        <input type="text" id="new-streamer-name" class="input" placeholder="streamer username">
+                        <button class="btn-small" id="btn-add-streamer"><i class="fa-solid fa-plus"></i> Add</button>
+                    </div>
+                </div>
+                <div id="per-channel-list"></div>
+            </div>
+            <div class="config-card">
+                <h3><i class="fa-solid fa-list-ol"></i> Priority Order</h3>
+                <p class="help">Drag to reorder or edit priority list (STREAK, DROPS, ORDER, etc.)</p>
+                <div id="priority-editor"></div>
+                <button class="btn-small" id="btn-save-priority">Save Priority</button>
             </div>
         </div>
     </div>
-</body>
 
 <script type="text/javascript">
-    // n.b. Seems that we are unable to call Flask variable in JS code imported from JS file.
-    // That's why "link[href='{{url_for('static', filename='dark-theme.css')}}']", {{ refresh }}, {{ daysAgo }} are here.
-
     function toggleDarkMode() {
         var darkMode = $('#dark-mode').prop("checked")
         $("link[href='{{url_for('static', filename='dark-theme.css')}}']").prop("disabled", !darkMode);
-        chart.updateOptions({
-            colors: darkMode === true ? ["#f9826c"] : ['#008ffb'],
-            chart: {
-                foreColor: darkMode === true ? "#fff" : '#373d3f'
-            },
-            tooltip: {
-                theme: darkMode === true ? "dark" : "light"
-            }
-        })
+        if (window.chart) {
+            chart.updateOptions({
+                colors: darkMode === true ? ["#f9826c"] : ['#008ffb'],
+                chart: { foreColor: darkMode === true ? "#fff" : '#373d3f' },
+                tooltip: { theme: darkMode === true ? "dark" : "light" },
+                grid: { borderColor: darkMode ? '#3a3d52' : '#e0e0e0' }
+            })
+        }
+        localStorage.setItem("dark-mode", darkMode)
     }
     var refresh = parseInt("{{ refresh }}");
     var daysAgo = parseInt("{{ daysAgo }}");
 </script>
 <script type="text/javascript" src="{{url_for('static', filename='script.js')}}"></script>
-
+</body>
 </html>

--- a/assets/script.js
+++ b/assets/script.js
@@ -1,389 +1,608 @@
-// https://apexcharts.com/javascript-chart-demos/line-charts/zoomable-timeseries/
 var options = {
     series: [],
     chart: {
         type: 'area',
         stacked: false,
-        height: 490,
-        zoom: {
-            type: 'x',
-            enabled: true,
-            autoScaleYaxis: true
-        },
-        // background: '#2B2D3E',
-        foreColor: '#fff'
+        height: 460,
+        zoom: { type: 'x', enabled: true, autoScaleYaxis: true },
+        foreColor: '#fff',
+        toolbar: { autoSelected: 'zoom' }
     },
-    dataLabels: {
-        enabled: false
-    },
-    stroke: {
-        curve: 'smooth',
-    },
-    markers: {
-        size: 0,
-    },
-    title: {
-        text: 'Channel points (dates are displayed in UTC)',
-        align: 'left'
-    },
-    colors: ["#f9826c"],
-    fill: {
-        type: 'gradient',
-        gradient: {
-            shadeIntensity: 1,
-            inverseColors: false,
-            opacityFrom: 0.5,
-            opacityTo: 0,
-            stops: [0, 90, 100]
-        },
-    },
-    yaxis: {
-        title: {
-            text: 'Channel points'
-        },
-    },
-    xaxis: {
-        type: 'datetime',
-        labels: {
-            datetimeUTC: false
-        }
-    },
+    dataLabels: { enabled: false },
+    stroke: { curve: 'smooth', width: 2 },
+    markers: { size: 0 },
+    title: { text: 'Channel points (UTC)', align: 'left' },
+    colors: ["#f9826c","#7aa2f7","#9ece6a","#e0af68","#bb9af7","#ff7eb6"],
+    fill: { type: 'gradient', gradient: { shadeIntensity: 1, inverseColors: false, opacityFrom: 0.5, opacityTo: 0, stops: [0, 90, 100] } },
+    yaxis: { title: { text: 'Channel points' }, labels: { formatter: v => millify(v) } },
+    xaxis: { type: 'datetime', labels: { datetimeUTC: false } },
     tooltip: {
         theme: 'dark',
         shared: false,
-        x: {
-            show: true,
-            format: 'HH:mm:ss dd MMM',
-        },
-        custom: ({
-            series,
-            seriesIndex,
-            dataPointIndex,
-            w
-        }) => {
-            return (`<div class="apexcharts-active">
-                <div class="apexcharts-tooltip-title">${w.globals.seriesNames[seriesIndex]}</div>
-                <div class="apexcharts-tooltip-series-group apexcharts-active" style="order: 1; display: flex; padding-bottom: 0px !important;">
-                    <div class="apexcharts-tooltip-text">
-                        <div class="apexcharts-tooltip-y-group">
-                            <span class="apexcharts-tooltip-text-label"><b>Points</b>: ${series[seriesIndex][dataPointIndex]}</span><br>
-                            <span class="apexcharts-tooltip-text-label"><b>Reason</b>: ${w.globals.seriesZ[seriesIndex][dataPointIndex] ? w.globals.seriesZ[seriesIndex][dataPointIndex] : ''}</span>
-                        </div>
-                    </div>
-                </div>
-                </div>`)
+        x: { show: true, format: 'HH:mm:ss dd MMM yyyy' },
+        custom: ({series, seriesIndex, dataPointIndex, w}) => {
+            const z = w.globals.seriesZ[seriesIndex]?.[dataPointIndex] || '';
+            return `<div class="apexcharts-active"><div class="apexcharts-tooltip-title">${w.globals.seriesNames[seriesIndex]}</div><div class="apexcharts-tooltip-series-group apexcharts-active" style="order:1;display:flex;padding-bottom:0px !important;"><div class="apexcharts-tooltip-text"><div class="apexcharts-tooltip-y-group"><span class="apexcharts-tooltip-text-label"><b>Points</b>: ${series[seriesIndex][dataPointIndex]}</span><br><span class="apexcharts-tooltip-text-label"><b>Reason</b>: ${z}</span></div></div></div></div>`
         }
     },
-    noData: {
-        text: 'Loading...'
-    }
+    noData: { text: 'No data – select a streamer' },
+    grid: { borderColor: '#3a3d52' }
 };
-
 var chart = new ApexCharts(document.querySelector("#chart"), options);
 var currentStreamer = null;
 var annotations = [];
-
 var streamersList = [];
-var sortBy = "Name ascending";
-var sortField = 'name';
-
-var startDate = new Date();
-startDate.setDate(startDate.getDate() - daysAgo);
+var streamersDetails = [];
+var sortBy = "Points descending";
+var sortField = 'points';
+var startDate = new Date(); startDate.setDate(startDate.getDate() - daysAgo);
 var endDate = new Date();
+var compareMode = false;
+var selectedCompare = new Set();
+var historyRows = [];
+var historyFiltered = [];
+var historyPage = 1; var historyPageSize = 25; var historySortField='x'; var historySortAsc=false;
+var enumsCache = null;
 
-$(document).ready(function () {
-    // Variable to keep track of whether log checkbox is checked
-    var isLogCheckboxChecked = $('#log').prop('checked');
+function millify(n){ if(n==null) return '-'; if(n>=1000000) return (n/1000000).toFixed(1)+'M'; if(n>=1000) return (n/1000).toFixed(1)+'k'; return String(n); }
+function formatDate(d){ const dd=new Date(d); const m=''+(dd.getMonth()+1), day=''+dd.getDate(), y=dd.getFullYear(); return [y, m.padStart(2,'0'), day.padStart(2,'0')].join('-'); }
+function formatDateTime(ts){ return new Date(ts).toLocaleString(); }
 
-    // Variable to keep track of whether auto-update log is active
-    var autoUpdateLog = true;
-
-    // Variable to keep track of the last received log index
-    var lastReceivedLogIndex = 0;
-
-    $('#auto-update-log').click(() => {
-        autoUpdateLog = !autoUpdateLog;
-        $('#auto-update-log').text(autoUpdateLog ? '⏸️' : '▶️');
-
-        if (autoUpdateLog) {
-            getLog();
-        }
-    });
-
-    // Function to get the full log content
-    function getLog() {
-        if (isLogCheckboxChecked) {
-            $.get(`/log?lastIndex=${lastReceivedLogIndex}`, function (data) {
-                // Process and display the new log entries received
-                $("#log-content").append(data);
-                // Scroll to the bottom of the log content
-                $("#log-content").scrollTop($("#log-content")[0].scrollHeight);
-
-                // Update the last received log index
-                lastReceivedLogIndex += data.length;
-
-                if (autoUpdateLog) {
-                    // Call getLog() again after a certain interval (e.g., 1 second)
-                    setTimeout(getLog, 1000);
-                }
-            });
-        }
-    }
-
-    // Retrieve the saved header visibility preference from localStorage
-    var headerVisibility = localStorage.getItem('headerVisibility');
-
-    // Set the initial header visibility based on the saved preference or default to 'visible'
-    if (headerVisibility === 'hidden') {
-        $('#toggle-header').prop('checked', false);
-        $('#header').hide();
-    } else {
-        $('#toggle-header').prop('checked', true);
-        $('#header').show();
-    }
-
-    // Handle the toggle header change event
-    $('#toggle-header').change(function () {
-        if (this.checked) {
-            $('#header').show();
-            // Save the header visibility preference as 'visible' in localStorage
-            localStorage.setItem('headerVisibility', 'visible');
-        } else {
-            $('#header').hide();
-            // Save the header visibility preference as 'hidden' in localStorage
-            localStorage.setItem('headerVisibility', 'hidden');
-        }
-    });
-
+$(document).ready(function(){
     chart.render();
+    // restore prefs
+    if(!localStorage.getItem("annotations")) localStorage.setItem("annotations", true);
+    if(!localStorage.getItem("dark-mode")) localStorage.setItem("dark-mode", true);
+    if(!localStorage.getItem("sort-by")) localStorage.setItem("sort-by", "Points descending");
+    if(!localStorage.getItem("compare-mode")) localStorage.setItem("compare-mode", false);
 
-    if (!localStorage.getItem("annotations")) localStorage.setItem("annotations", true);
-    if (!localStorage.getItem("dark-mode")) localStorage.setItem("dark-mode", true);
-    if (!localStorage.getItem("sort-by")) localStorage.setItem("sort-by", "Name ascending");
-
-    // Restore settings from localStorage on page load
-    $('#annotations').prop("checked", localStorage.getItem("annotations") === "true");
-    $('#dark-mode').prop("checked", localStorage.getItem("dark-mode") === "true");
-
-    // Handle the annotation toggle click event
-    $('#annotations').click(() => {
-        var isChecked = $('#annotations').prop("checked");
-        localStorage.setItem("annotations", isChecked);
-        updateAnnotations();
-    });
-
-    // Handle the dark mode toggle click event
-    $('#dark-mode').click(() => {
-        var isChecked = $('#dark-mode').prop("checked");
-        localStorage.setItem("dark-mode", isChecked);
-        toggleDarkMode();
-    });
-
+    $('#annotations').prop("checked", localStorage.getItem("annotations")==="true");
+    $('#dark-mode').prop("checked", localStorage.getItem("dark-mode")==="true");
+    compareMode = localStorage.getItem("compare-mode")==="true";
+    $('#compare-mode').prop("checked", compareMode);
+    sortBy = localStorage.getItem("sort-by");
+    if(sortBy.includes("Points")) sortField='points';
+    else if(sortBy.includes("Gained")) sortField='total_gained';
+    else if(sortBy.includes("Last activity")) sortField='last_activity';
+    else sortField='name';
+    $('#sorting-by').text(sortBy);
     $('#startDate').val(formatDate(startDate));
     $('#endDate').val(formatDate(endDate));
 
-    sortBy = localStorage.getItem("sort-by");
-    if (sortBy.includes("Points")) sortField = 'points';
-    else if (sortBy.includes("Last activity")) sortField = 'last_activity';
-    else sortField = 'name';
-    $('#sorting-by').text(sortBy);
+    // tabs
+    $('.tab-btn').click(function(){
+        const t=$(this).data('tab');
+        $('.tab-btn').removeClass('active'); $(this).addClass('active');
+        $('.tab-pane').removeClass('active'); $('#tab-'+t).addClass('active');
+        if(t==='history' && historyRows.length===0) loadHistory();
+        if(t==='config') loadConfig();
+    });
+
+    // header toggle
+    var hv=localStorage.getItem('headerVisibility');
+    if(hv==='hidden'){ $('#toggle-header').prop('checked',false); $('#header').hide(); }
+    $('#toggle-header').change(function(){ if(this.checked){$('#header').show(); localStorage.setItem('headerVisibility','visible');} else {$('#header').hide(); localStorage.setItem('headerVisibility','hidden');}});
+
+    $('#annotations').click(()=>{ localStorage.setItem("annotations", $('#annotations').prop("checked")); updateAnnotations(); });
+    $('#dark-mode').click(()=> toggleDarkMode());
+    $('#compare-mode').change(function(){ compareMode=this.checked; localStorage.setItem("compare-mode", compareMode); selectedCompare.clear(); if(compareMode && currentStreamer) selectedCompare.add(currentStreamer.replace('.json','')); updateCompareUI(); if(currentStreamer) getStreamerData(currentStreamer); });
+    $('.preset-btn').click(function(){ $('.preset-btn').removeClass('active'); $(this).addClass('active'); const d=$(this).data('days'); if(d==='all'){ $('#startDate').val(''); $('#endDate').val(formatDate(new Date())); startDate=new Date(0); endDate=new Date(); } else { const n=parseInt(d); startDate=new Date(); startDate.setDate(startDate.getDate()-n); endDate=new Date(); $('#startDate').val(formatDate(startDate)); $('#endDate').val(formatDate(endDate)); } if(currentStreamer) refreshChart(); });
+    $('#startDate').change(()=>{ const v=$('#startDate').val(); if(v) startDate=new Date(v); if(currentStreamer) refreshChart(); });
+    $('#endDate').change(()=>{ const v=$('#endDate').val(); if(v) endDate=new Date(v); if(currentStreamer) refreshChart(); });
+    $('#agg-select').change(()=>{ if(currentStreamer) refreshChart(); });
+    $('#btn-export').click(exportCSV);
+    $('#btn-reset-zoom').click(()=> chart.resetSeries(false,true));
+    $('#streamer-search').on('input', renderStreamers);
+    $('#btn-history-refresh').click(loadHistory);
+    $('#history-streamer-filter, #history-type-filter').change(applyHistoryFilters);
+    $('#history-search').on('input', applyHistoryFilters);
+    $('.history-table th[data-sort]').click(function(){ const f=$(this).data('sort'); if(historySortField===f) historySortAsc=!historySortAsc; else {historySortField=f; historySortAsc=true;} renderHistoryTable(); });
+    $('#btn-save-global').click(saveGlobalConfig);
+    $('#btn-add-streamer').click(addStreamer);
+    $('#btn-save-priority').click(savePriority);
+
+    toggleDarkMode();
+    loadOverview();
     getStreamers();
 
+    // log toggle
+    var isLogChecked = localStorage.getItem('logCheckboxState')==='true';
+    $('#log').prop('checked', isLogChecked);
+    if(isLogChecked) { $('#log-box').show(); startLogPoll(); }
+    $('#log').change(function(){ const c=$(this).prop('checked'); localStorage.setItem('logCheckboxState', c); if(c){ $('#log-box').show(); startLogPoll(); } else { $('#log-box').hide(); } });
+
     updateAnnotations();
-    toggleDarkMode();
-
-    // Retrieve log checkbox state from localStorage and update UI accordingly
-    var logCheckboxState = localStorage.getItem('logCheckboxState');
-    $('#log').prop('checked', logCheckboxState === 'true');
-    if (logCheckboxState === 'true') {
-        isLogCheckboxChecked = true;
-        $('#auto-update-log').show();
-        $('#log-box').show();
-        // Start continuously updating the log content
-        getLog();
-    }
-
-    // Handle the log checkbox change event
-    $('#log').change(function () {
-        isLogCheckboxChecked = $(this).prop('checked');
-        localStorage.setItem('logCheckboxState', isLogCheckboxChecked);
-
-        if (isLogCheckboxChecked) {
-            $('#log-box').show();
-            $('#auto-update-log').show();
-            getLog();
-            $('html, body').scrollTop($(document).height());
-        } else {
-            $('#log-box').hide();
-            $('#auto-update-log').hide();
-            // Clear log content when checkbox is unchecked
-            // $("#log-content").text('');
-        }
-    });
 });
 
-function formatDate(date) {
-    var d = new Date(date),
-        month = '' + (d.getMonth() + 1),
-        day = '' + d.getDate(),
-        year = d.getFullYear();
+function refreshChart(){ if(compareMode && selectedCompare.size>1) loadCompareChart(); else if(currentStreamer) getStreamerData(currentStreamer); }
 
-    if (month.length < 2) month = '0' + month;
-    if (day.length < 2) day = '0' + day;
-
-    return [year, month, day].join('-');
+function loadOverview(){
+    $.getJSON('/api/overview', function(data){
+        $('#stat-streamers').text(data.total_streamers);
+        $('#stat-points').text(millify(data.total_points));
+        $('#stat-gained').text(millify(data.total_gained));
+        $('#stat-winrate').text(data.win_rate);
+    });
+    $.getJSON('/api/streamers/details', function(data){
+        streamersDetails = data;
+        // update overview if needed
+    });
 }
 
-function changeStreamer(streamer, index) {
-    $("li").removeClass("is-active")
-    $("li").eq(index - 1).addClass('is-active');
-    currentStreamer = streamer;
-
-    // Update the chart title with the current streamer's name
-    options.title.text = `${streamer.replace(".json", "")}'s channel points (dates are displayed in UTC)`;
-    chart.updateOptions(options);
-
-    // Save the selected streamer in localStorage
-    localStorage.setItem("selectedStreamer", currentStreamer);
-
-    getStreamerData(streamer);
+function getStreamers(){
+    // use detailed endpoint for richer sorting
+    $.getJSON('/api/streamers/details', function(response){
+        // fallback to simple /streamers if details empty
+        if(!response || response.length===0){
+            $.getJSON('streamers', function(simple){
+                streamersList = simple.map(s=>({name:s.name, points:s.points, last_activity:s.last_activity, total_gained:0}));
+                sortStreamers(); renderStreamers();
+            });
+            return;
+        }
+        streamersDetails = response;
+        streamersList = response.map(d=>({ name: d.file || d.name+'.json', displayName: d.name, points: d.points, last_activity: d.last_activity, total_gained: d.total_gained, is_online: d.is_online, bets: d.bets }));
+        sortStreamers();
+        renderStreamers();
+        // also populate history filter dropdown
+        const sel=$('#history-streamer-filter'); sel.find('option:not(:first)').remove();
+        response.forEach(d=> sel.append(`<option value="${d.name}">${d.name}</option>`));
+    });
 }
 
-function getStreamerData(streamer) {
-    if (currentStreamer == streamer) {
-        $.getJSON(`./json/${streamer}`, {
-            startDate: formatDate(startDate),
-            endDate: formatDate(endDate)
-        }, function (response) {
-            chart.updateSeries([{
-                name: streamer.replace(".json", ""),
-                data: response["series"]
-            }], true)
-            clearAnnotations();
-            annotations = response["annotations"];
-            updateAnnotations();
-            setTimeout(function () {
-                getStreamerData(streamer);
-            }, 300000); // 5 minutes
-        });
+function renderStreamers(){
+    const query = ($('#streamer-search').val()||'').toLowerCase();
+    let filtered = streamersList.filter(s=> !query || s.displayName?.toLowerCase().includes(query) || s.name.toLowerCase().includes(query));
+    $("#streamers-list").empty();
+    $("#streamer-count").text(filtered.length);
+    let idx=1;
+    filtered.forEach((streamer)=>{
+        const name = streamer.displayName || streamer.name.replace(".json","");
+        const isActive = currentStreamer === streamer.name;
+        let display = name;
+        if(sortField==='points') display = `<span class="points">${millify(streamer.points)}</span> ${name}`;
+        else if(sortField==='total_gained') display = `<span class="points">+${millify(streamer.total_gained)}</span> ${name}`;
+        else if(sortField==='last_activity') display = `<span class="meta">${formatDate(streamer.last_activity)}</span> ${name}`;
+        if(streamer.is_online) display = `<span class="dot online" title="Online"></span> `+display;
+        else if(streamer.is_online===false) display = `<span class="dot offline" title="Offline"></span> `+display;
+        const activeClass = isActive ? 'is-active' : '';
+        const compareChecked = selectedCompare.has(name) ? 'checked' : '';
+        const checkbox = compareMode ? `<input type="checkbox" class="compare-check" data-name="${name}" ${compareChecked} style="margin-right:6px">` : '';
+        const li = `<li class="${activeClass}"><a onClick="handleStreamerClick('${streamer.name}', '${name}'); return false;">${checkbox}${display}<span class="meta" style="margin-left:auto">${streamer.bets ? streamer.bets.win_rate+'% WR' : ''}</span></a></li>`;
+        $("#streamers-list").append(li);
+        idx++;
+    });
+    // after render, restore selection
+    if(!currentStreamer && filtered.length>0){
+        const saved = localStorage.getItem("selectedStreamer");
+        const exists = filtered.find(s=> s.name===saved);
+        const target = exists ? saved : filtered[0].name;
+        const targetDisplay = filtered.find(s=> s.name===target).displayName || target.replace(".json","");
+        changeStreamer(target, 1);
+    } else if(currentStreamer){
+        // ensure active visible
+    }
+    $('.compare-check').change(function(e){
+        e.stopPropagation();
+        const nm=$(this).data('name');
+        if(this.checked) selectedCompare.add(nm); else selectedCompare.delete(nm);
+        if(selectedCompare.size===0 && currentStreamer) selectedCompare.add(currentStreamer.replace(".json",""));
+        loadCompareChart();
+    });
+}
+
+function handleStreamerClick(file, displayName){
+    if(compareMode){
+        if(selectedCompare.has(displayName)) selectedCompare.delete(displayName); else selectedCompare.add(displayName);
+        if(selectedCompare.size===0) selectedCompare.add(displayName);
+        currentStreamer=file;
+        localStorage.setItem("selectedStreamer", file);
+        renderStreamers();
+        loadCompareChart();
+    } else {
+        changeStreamer(file, 1);
     }
 }
+function updateCompareUI(){ renderStreamers(); }
 
-function getAllStreamersData() {
-    $.getJSON(`./json_all`, function (response) {
-        for (var i in response) {
-            chart.appendSeries({
-                name: response[i]["name"].replace(".json", ""),
-                data: response[i]["data"]["series"]
-            }, true)
-        }
+function sortStreamers(){
+    streamersList = streamersList.sort((a,b)=>{
+        let av=a[sortField], bv=b[sortField];
+        if(sortField==='name') { av=(a.displayName||a.name).toLowerCase(); bv=(b.displayName||b.name).toLowerCase(); }
+        let cmp = av > bv ? 1 : av < bv ? -1 : 0;
+        return cmp * (sortBy.includes("ascending") ? 1 : -1);
     });
 }
-
-function getStreamers() {
-    $.getJSON('streamers', function (response) {
-        streamersList = response;
-        sortStreamers();
-
-        // Restore the selected streamer from localStorage on page load
-        var selectedStreamer = localStorage.getItem("selectedStreamer");
-
-        if (selectedStreamer) {
-            currentStreamer = selectedStreamer;
-        } else {
-            // If no selected streamer is found, default to the first streamer in the list
-            currentStreamer = streamersList.length > 0 ? streamersList[0].name : null;
-        }
-
-        // Ensure the selected streamer is still active and scrolled into view
-        renderStreamers();
-    });
-}
-
-function renderStreamers() {
-    $("#streamers-list").empty();
-    var promised = new Promise((resolve, reject) => {
-        streamersList.forEach((streamer, index, array) => {
-            displayname = streamer.name.replace(".json", "");
-            if (sortField == 'points') displayname = "<font size='-2'>" + streamer['points'] + "</font>&nbsp;" + displayname;
-            else if (sortField == 'last_activity') displayname = "<font size='-2'>" + formatDate(streamer['last_activity']) + "</font>&nbsp;" + displayname;
-            var isActive = currentStreamer === streamer.name;
-            if (!isActive && localStorage.getItem("selectedStreamer") === null && index === 0) {
-                isActive = true;
-                currentStreamer = streamer.name;
-            }
-            var activeClass = isActive ? 'is-active' : '';
-            var listItem = `<li id="streamer-${streamer.name}" class="${activeClass}"><a onClick="changeStreamer('${streamer.name}', ${index + 1}); return false;">${displayname}</a></li>`;
-            $("#streamers-list").append(listItem);
-            if (isActive) {
-                // Scroll the selected streamer into view
-                document.getElementById(`streamer-${streamer.name}`).scrollIntoView({
-                    behavior: 'smooth',
-                    block: 'center'
-                });
-            }
-            if (index === array.length - 1) resolve();
-        });
-    });
-    promised.then(() => {
-        changeStreamer(currentStreamer, streamersList.findIndex(streamer => streamer.name === currentStreamer) + 1);
-    });
-}
-
-function sortStreamers() {
-    streamersList = streamersList.sort((a, b) => {
-        return (a[sortField] > b[sortField] ? 1 : -1) * (sortBy.includes("ascending") ? 1 : -1);
-    });
-}
-
-function changeSortBy(option) {
+function changeSortBy(option){
     sortBy = option.innerText.trim();
-    if (sortBy.includes("Points")) sortField = 'points'
-    else if (sortBy.includes("Last activity")) sortField = 'last_activity'
-    else sortField = 'name';
-    sortStreamers();
-    renderStreamers();
+    if(sortBy.includes("Points")) sortField='points';
+    else if(sortBy.includes("Gained")) sortField='total_gained';
+    else if(sortBy.includes("Last activity")) sortField='last_activity';
+    else sortField='name';
+    sortStreamers(); renderStreamers();
     $('#sorting-by').text(sortBy);
     localStorage.setItem("sort-by", sortBy);
 }
 
-function updateAnnotations() {
-    if ($('#annotations').prop("checked") === true) {
-        clearAnnotations()
-        if (annotations && annotations.length > 0)
-            annotations.forEach((annotation, index) => {
-                annotations[index]['id'] = `id-${index}`
-                chart.addXaxisAnnotation(annotation, true)
-            })
-    } else clearAnnotations()
+function changeStreamer(streamer, index){
+    $("li").removeClass("is-active");
+    // active will be set via render
+    currentStreamer = streamer;
+    options.title.text = `${streamer.replace(".json","")}'s channel points (UTC)`;
+    chart.updateOptions(options);
+    localStorage.setItem("selectedStreamer", currentStreamer);
+    getStreamerData(streamer);
+    updateChartStats(streamer);
+    renderStreamers();
 }
 
-function clearAnnotations() {
-    if (annotations && annotations.length > 0)
-        annotations.forEach((annotation, index) => {
-            chart.removeAnnotation(annotation['id'])
-        })
-    chart.clearAnnotations();
+function getStreamerData(streamer){
+    if(!streamer) return;
+    const freq = $('#agg-select').val();
+    const params = { startDate: $('#startDate').val() || formatDate(startDate), endDate: $('#endDate').val() || formatDate(endDate) };
+    // use new aggregate endpoint if freq != raw
+    const url = freq && freq!=='raw' ? `./api/series/${streamer}?freq=${freq}` : `./json/${streamer}`;
+    $.getJSON(url, params, function(response){
+        if(response.error){ chart.updateSeries([{name: streamer.replace(".json",""), data:[]} ]); return; }
+        // if compare mode with single, still show single
+        if(compareMode && selectedCompare.size>1) return; // compare will override
+        chart.updateSeries([{ name: streamer.replace(".json",""), data: response["series"] }], true);
+        clearAnnotations();
+        annotations = response["annotations"] || [];
+        updateAnnotations();
+        // update stats
+        const series = response["series"] || [];
+        if(series.length>0){
+            const first = series[0].y, last = series[series.length-1].y;
+            const gained = last - first;
+            $('#chart-stats').html(`<span class="stat-chip">Points: ${millify(last)}</span><span class="stat-chip">Gained: +${millify(gained)}</span><span class="stat-chip">Samples: ${series.length}</span>`);
+            // breakdown
+            const zCounts = {}; series.forEach(s=>{ const z=s.z||'Unknown'; zCounts[z]=(zCounts[z]||0)+1; });
+            let html='';
+            for(const k in zCounts){ html+=`<div class="gain-card"><b>${k}</b><br>${zCounts[k]} events</div>`; }
+            $('#gain-breakdown').html(html);
+        }
+    });
 }
 
-// Toggle
-$('#annotations').click(() => {
-    updateAnnotations();
-});
-$('#dark-mode').click(() => {
-    toggleDarkMode();
+function loadCompareChart(){
+    if(!compareMode || selectedCompare.size===0) return;
+    const freq = $('#agg-select').val();
+    const params = { startDate: $('#startDate').val() || formatDate(startDate), endDate: $('#endDate').val() || formatDate(endDate) };
+    chart.updateSeries([]); clearAnnotations();
+    let promises = [];
+    selectedCompare.forEach(name=>{
+        const file = name+'.json';
+        const url = freq && freq!=='raw' ? `./api/series/${file}?freq=${freq}` : `./json/${file}`;
+        promises.push($.getJSON(url, params).then(res=> ({name, data: res.series || []})));
+    });
+    Promise.all(promises).then(results=>{
+        const series = results.map(r=> ({name: r.name, data: r.data}));
+        chart.updateSeries(series, true);
+        options.title.text = `Compare: ${Array.from(selectedCompare).join(', ')}`;
+        chart.updateOptions(options);
+        $('#chart-stats').html(`<span class="stat-chip">Comparing ${selectedCompare.size} streamers</span>`);
+        $('#gain-breakdown').html('');
+    });
+}
+
+function updateChartStats(streamer){
+    const detail = streamersDetails.find(d=> d.name===streamer.replace(".json",""));
+    if(detail){
+        const b=detail.bets||{};
+        $('#chart-stats').html(`<span class="stat-chip">Bets: ${b.placed||0}</span><span class="stat-chip">Wins: ${b.wins||0}</span><span class="stat-chip">WR: ${b.win_rate||0}%</span>`);
+    }
+}
+
+function updateAnnotations(){
+    if($('#annotations').prop("checked")){
+        clearAnnotations();
+        if(annotations && annotations.length>0) annotations.forEach((ann,idx)=>{ ann.id=`id-${idx}`; chart.addXaxisAnnotation(ann,true); });
+    } else clearAnnotations();
+}
+function clearAnnotations(){ if(annotations) annotations.forEach((a,i)=>{ try{chart.removeAnnotation(a.id||`id-${i}`)}catch(e){}}); chart.clearAnnotations(); }
+
+// log
+let lastReceivedLogIndex=0, autoUpdateLog=true, logTimer=null;
+function startLogPoll(){ lastReceivedLogIndex=0; $('#log-content').text(''); pollLog(); }
+function pollLog(){
+    if(!$('#log').prop("checked")) return;
+    $.get(`/log?lastIndex=${lastReceivedLogIndex}`, function(data){
+        $("#log-content").append(data);
+        $("#log-content").scrollTop($("#log-content")[0].scrollHeight);
+        lastReceivedLogIndex += data.length;
+        if(autoUpdateLog) logTimer=setTimeout(pollLog,1000);
+    }).fail(()=>{ if(autoUpdateLog) logTimer=setTimeout(pollLog,3000); });
+}
+$('#auto-update-log').click(()=>{
+    autoUpdateLog=!autoUpdateLog;
+    $('#auto-update-log').text(autoUpdateLog ? '⏸️' : '▶️');
+    if(autoUpdateLog) pollLog();
 });
 
-$('.dropdown').click(() => {
-    $('.dropdown').toggleClass('is-active');
-});
+function exportCSV(){
+    if(!currentStreamer) return;
+    const series = chart.w.globals.series[0] ? chart.w.globals.series[0] : [];
+    // better fetch raw data again
+    $.getJSON(`./json/${currentStreamer}`, {startDate: $('#startDate').val(), endDate: $('#endDate').val()}, function(res){
+        let csv='x,y,z\n';
+        (res.series||[]).forEach(r=>{ csv+=`${new Date(r.x).toISOString()},${r.y},"${r.z}"\n`; });
+        const blob=new Blob([csv],{type:'text/csv'});
+        const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download=`${currentStreamer.replace('.json','')}_points.csv`; a.click();
+    });
+}
 
-// Input date
-$('#startDate').change(() => {
-    startDate = new Date($('#startDate').val());
-    getStreamerData(currentStreamer);
-});
-$('#endDate').change(() => {
-    endDate = new Date($('#endDate').val());
-    getStreamerData(currentStreamer);
-});
+// History
+function loadHistory(){
+    const streamer = $('#history-streamer-filter').val();
+    const params = {};
+    if(streamer) params.streamer=streamer;
+    params.limit=500;
+    $.getJSON('/api/bets', params, function(data){
+        historyRows = data;
+        applyHistoryFilters();
+        // summary
+        const wins = data.filter(r=>r.type==='WIN').length;
+        const losses = data.filter(r=>r.type==='LOSE').length;
+        const placed = data.filter(r=>r.type==='BET_PLACED').length;
+        const streaks = data.filter(r=>r.type==='WATCH_STREAK').length;
+        const wr = wins+losses>0 ? ((wins/(wins+losses))*100).toFixed(1) : 0;
+        $('#history-summary').html(`<span class="stat-chip">Bets: ${placed}</span><span class="stat-chip" style="color:#36b535">Wins: ${wins}</span><span class="stat-chip" style="color:#ff4545">Losses: ${losses}</span><span class="stat-chip">WR: ${wr}%</span><span class="stat-chip">Streaks: ${streaks}</span>`);
+    });
+}
+function applyHistoryFilters(){
+    const type = $('#history-type-filter').val();
+    const streamer = $('#history-streamer-filter').val();
+    const q = ($('#history-search').val()||'').toLowerCase();
+    historyFiltered = historyRows.filter(r=>{
+        if(type && r.type!==type) return false;
+        if(streamer && r.streamer!==streamer) return false;
+        if(q && ! (r.text.toLowerCase().includes(q) || r.streamer.toLowerCase().includes(q) || r.type.toLowerCase().includes(q))) return false;
+        return true;
+    });
+    // sort
+    historyFiltered.sort((a,b)=>{
+        let av=a[historySortField], bv=b[historySortField];
+        if(historySortField==='datetime') { av=a.x; bv=b.x; }
+        if(av===bv) return 0;
+        const cmp = av > bv ? 1 : -1;
+        return historySortAsc ? cmp : -cmp;
+    });
+    historyPage=1;
+    renderHistoryTable();
+}
+function renderHistoryTable(){
+    const tbody=$('#history-body'); tbody.empty();
+    if(historyFiltered.length===0){ tbody.append('<tr><td colspan="5" class="empty">No records</td></tr>'); $('#history-pagination').empty(); return; }
+    const totalPages=Math.ceil(historyFiltered.length/historyPageSize);
+    if(historyPage>totalPages) historyPage=totalPages;
+    const start=(historyPage-1)*historyPageSize;
+    const pageRows=historyFiltered.slice(start, start+historyPageSize);
+    pageRows.forEach(r=>{
+        const badge=`<span class="badge-type ${r.type}">${r.type}</span>`;
+        const bal = r.balance!=null ? millify(r.balance) : '-';
+        tbody.append(`<tr><td>${r.datetime? new Date(r.x).toLocaleString(): '-'}</td><td>${r.streamer}</td><td>${badge}</td><td>${r.text}</td><td>${bal}</td></tr>`);
+    });
+    // pagination
+    let pagHtml='';
+    for(let i=1;i<=totalPages;i++){ pagHtml+=`<button class="btn-small ${i===historyPage?'active':''}" onclick="goHistoryPage(${i})">${i}</button>`; }
+    $('#history-pagination').html(pagHtml);
+}
+function goHistoryPage(p){ historyPage=p; renderHistoryTable(); }
+
+// Config
+function loadConfig(){
+    $.getJSON('/api/enums', function(enums){ enumsCache=enums; });
+    $.getJSON('/api/config', function(cfg){
+        renderGlobalConfig(cfg.global, cfg.priority);
+        renderPerChannel(cfg.streamers);
+        renderPriority(cfg.priority);
+    });
+}
+function renderGlobalConfig(global, priority){
+    const c=$('#global-config-form'); c.empty();
+    if(!global) { c.html('<p class="empty">No config</p>'); return; }
+    const bet=global.bet||{};
+    const fc=bet.filter_condition||{};
+    c.html(`
+        <div class="form-grid">
+            <div class="form-group"><label>Make predictions</label><select id="g_make_predictions"><option value="true">True</option><option value="false">False</option></select></div>
+            <div class="form-group"><label>Follow raid</label><select id="g_follow_raid"><option value="true">True</option><option value="false">False</option></select></div>
+            <div class="form-group"><label>Claim drops</label><select id="g_claim_drops"><option value="true">True</option><option value="false">False</option></select></div>
+            <div class="form-group"><label>Claim moments</label><select id="g_claim_moments"><option value="true">True</option><option value="false">False</option></select></div>
+            <div class="form-group"><label>Watch streak</label><select id="g_watch_streak"><option value="true">True</option><option value="false">False</option></select></div>
+            <div class="form-group"><label>Community goals</label><select id="g_community_goals"><option value="true">True</option><option value="false">False</option></select></div>
+            <div class="form-group"><label>Chat presence</label><select id="g_chat"></select></div>
+        </div>
+        <h4 style="margin:10px 0 6px">Bet Settings</h4>
+        <div class="form-grid">
+            <div class="form-group"><label>Strategy</label><select id="g_strategy"></select></div>
+            <div class="form-group"><label>Percentage %</label><input id="g_percentage" type="number" min="1" max="100"></div>
+            <div class="form-group"><label>Percentage gap</label><input id="g_percentage_gap" type="number"></div>
+            <div class="form-group"><label>Max points</label><input id="g_max_points" type="number"></div>
+            <div class="form-group"><label>Minimum points</label><input id="g_minimum_points" type="number"></div>
+            <div class="form-group"><label>Stealth mode</label><select id="g_stealth_mode"><option value="true">True</option><option value="false">False</option></select></div>
+            <div class="form-group"><label>Delay mode</label><select id="g_delay_mode"></select></div>
+            <div class="form-group"><label>Delay</label><input id="g_delay" type="number" step="0.1"></div>
+            <div class="form-group"><label>Filter by</label><select id="g_filter_by"><option value="">None</option></select></div>
+            <div class="form-group"><label>Where</label><select id="g_filter_where"><option value="">-</option></select></div>
+            <div class="form-group"><label>Value</label><input id="g_filter_value" type="number"></div>
+        </div>
+    `);
+    // populate enums
+    if(enumsCache){
+        $('#g_chat').html(enumsCache.chat_presences.map(v=>`<option value="${v}">${v}</option>`).join(''));
+        $('#g_strategy').html(enumsCache.strategies.map(v=>`<option value="${v}">${v}</option>`).join(''));
+        $('#g_delay_mode').html(enumsCache.delay_modes.map(v=>`<option value="${v}">${v}</option>`).join(''));
+        $('#g_filter_by').html('<option value="">None</option>'+enumsCache.outcome_keys.map(v=>`<option value="${v}">${v}</option>`).join(''));
+        $('#g_filter_where').html('<option value="">-</option>'+enumsCache.conditions.map(v=>`<option value="${v}">${v}</option>`).join(''));
+    }
+    $('#g_make_predictions').val(String(global.make_predictions));
+    $('#g_follow_raid').val(String(global.follow_raid));
+    $('#g_claim_drops').val(String(global.claim_drops));
+    $('#g_claim_moments').val(String(global.claim_moments));
+    $('#g_watch_streak').val(String(global.watch_streak));
+    $('#g_community_goals').val(String(global.community_goals));
+    $('#g_chat').val(global.chat);
+    $('#g_strategy').val(bet.strategy);
+    $('#g_percentage').val(bet.percentage);
+    $('#g_percentage_gap').val(bet.percentage_gap);
+    $('#g_max_points').val(bet.max_points);
+    $('#g_minimum_points').val(bet.minimum_points);
+    $('#g_stealth_mode').val(String(bet.stealth_mode));
+    $('#g_delay_mode').val(bet.delay_mode);
+    $('#g_delay').val(bet.delay);
+    if(fc && fc.by){ $('#g_filter_by').val(fc.by); $('#g_filter_where').val(fc.where); $('#g_filter_value').val(fc.value); }
+}
+function saveGlobalConfig(){
+    const global={
+        make_predictions: $('#g_make_predictions').val()==='true',
+        follow_raid: $('#g_follow_raid').val()==='true',
+        claim_drops: $('#g_claim_drops').val()==='true',
+        claim_moments: $('#g_claim_moments').val()==='true',
+        watch_streak: $('#g_watch_streak').val()==='true',
+        community_goals: $('#g_community_goals').val()==='true',
+        chat: $('#g_chat').val(),
+        bet:{
+            strategy: $('#g_strategy').val(),
+            percentage: parseInt($('#g_percentage').val()||5),
+            percentage_gap: parseInt($('#g_percentage_gap').val()||20),
+            max_points: parseInt($('#g_max_points').val()||50000),
+            minimum_points: parseInt($('#g_minimum_points').val()||0),
+            stealth_mode: $('#g_stealth_mode').val()==='true',
+            delay_mode: $('#g_delay_mode').val(),
+            delay: parseFloat($('#g_delay').val()||6),
+            filter_condition: $('#g_filter_by').val() ? {by: $('#g_filter_by').val(), where: $('#g_filter_where').val(), value: parseInt($('#g_filter_value').val()||0)} : null
+        }
+    };
+    $.ajax({url:'/api/config', method:'PUT', contentType:'application/json', data: JSON.stringify({global}), success:function(res){
+        $('#global-save-status').text('Saved ✔').removeClass('err').addClass('ok'); setTimeout(()=>$('#global-save-status').text(''),3000);
+    }, error:function(xhr){ $('#global-save-status').text('Error: '+xhr.responseText).addClass('err'); }});
+}
+function renderPerChannel(streamers){
+    const c=$('#per-channel-list'); c.empty();
+    if(!streamers || Object.keys(streamers).length===0){ c.html('<p class="empty">No per-channel overrides. Global settings apply to all. Click Add to create per-channel config.</p>'); return; }
+    Object.entries(streamers).forEach(([name, cfg])=>{
+        const hasCfg = cfg!==null && cfg!==undefined;
+        const bet = hasCfg && cfg.bet ? cfg.bet : {};
+        const fc = bet.filter_condition||{};
+        const row=$(`
+            <div class="channel-row" id="ch-${name}">
+                <div class="channel-header" onclick="$(this).parent().toggleClass('open')">
+                    <span class="name"><i class="fa-solid fa-user"></i> ${name} ${hasCfg?'':'<span style="color:var(--muted);font-weight:400">(using global)</span>'}</span>
+                    <div class="channel-actions">
+                        <button class="btn-small" onclick="event.stopPropagation(); saveChannel('${name}')"><i class="fa-solid fa-floppy-disk"></i> Save</button>
+                        <button class="btn-small" onclick="event.stopPropagation(); deleteChannel('${name}')" title="Delete"><i class="fa-solid fa-trash"></i></button>
+                        <i class="fa-solid fa-chevron-down"></i>
+                    </div>
+                </div>
+                <div class="channel-body">
+                    <div class="form-grid">
+                        <div class="form-group"><label>Make predictions</label><select id="${name}_make_predictions"><option value="">Global</option><option value="true">True</option><option value="false">False</option></select></div>
+                        <div class="form-group"><label>Follow raid</label><select id="${name}_follow_raid"><option value="">Global</option><option value="true">True</option><option value="false">False</option></select></div>
+                        <div class="form-group"><label>Claim drops</label><select id="${name}_claim_drops"><option value="">Global</option><option value="true">True</option><option value="false">False</option></select></div>
+                        <div class="form-group"><label>Chat</label><select id="${name}_chat"><option value="">Global</option></select></div>
+                        <div class="form-group"><label>Strategy</label><select id="${name}_strategy"><option value="">Global</option></select></div>
+                        <div class="form-group"><label>Percentage</label><input id="${name}_percentage" type="number" placeholder="Global"></div>
+                        <div class="form-group"><label>Max points</label><input id="${name}_max_points" type="number" placeholder="Global"></div>
+                        <div class="form-group"><label>Stealth</label><select id="${name}_stealth_mode"><option value="">Global</option><option value="true">True</option><option value="false">False</option></select></div>
+                        <div class="form-group"><label>Delay mode</label><select id="${name}_delay_mode"><option value="">Global</option></select></div>
+                        <div class="form-group"><label>Delay</label><input id="${name}_delay" type="number" step="0.1" placeholder="Global"></div>
+                        <div class="form-group"><label>Filter by</label><select id="${name}_filter_by"><option value="">None/Global</option></select></div>
+                        <div class="form-group"><label>Where</label><select id="${name}_filter_where"><option value="">-</option></select></div>
+                        <div class="form-group"><label>Value</label><input id="${name}_filter_value" type="number" placeholder="Global"></div>
+                    </div>
+                    <div class="save-status" id="${name}-status"></div>
+                </div>
+            </div>
+        `);
+        c.append(row);
+        if(enumsCache){
+            $(`#${name}_chat`).append(enumsCache.chat_presences.map(v=>`<option value="${v}">${v}</option>`).join(''));
+            $(`#${name}_strategy`).append(enumsCache.strategies.map(v=>`<option value="${v}">${v}</option>`).join(''));
+            $(`#${name}_delay_mode`).append(enumsCache.delay_modes.map(v=>`<option value="${v}">${v}</option>`).join(''));
+            $(`#${name}_filter_by`).append(enumsCache.outcome_keys.map(v=>`<option value="${v}">${v}</option>`).join(''));
+            $(`#${name}_filter_where`).append(enumsCache.conditions.map(v=>`<option value="${v}">${v}</option>`).join(''));
+        }
+        if(hasCfg){
+            if(cfg.make_predictions!==undefined && cfg.make_predictions!==null) $(`#${name}_make_predictions`).val(String(cfg.make_predictions));
+            if(cfg.follow_raid!==undefined && cfg.follow_raid!==null) $(`#${name}_follow_raid`).val(String(cfg.follow_raid));
+            if(cfg.claim_drops!==undefined && cfg.claim_drops!==null) $(`#${name}_claim_drops`).val(String(cfg.claim_drops));
+            if(cfg.chat) $(`#${name}_chat`).val(cfg.chat);
+            if(bet.strategy) $(`#${name}_strategy`).val(bet.strategy);
+            if(bet.percentage!==undefined) $(`#${name}_percentage`).val(bet.percentage);
+            if(bet.max_points!==undefined) $(`#${name}_max_points`).val(bet.max_points);
+            if(bet.stealth_mode!==undefined) $(`#${name}_stealth_mode`).val(String(bet.stealth_mode));
+            if(bet.delay_mode) $(`#${name}_delay_mode`).val(bet.delay_mode);
+            if(bet.delay!==undefined) $(`#${name}_delay`).val(bet.delay);
+            if(fc.by) $(`#${name}_filter_by`).val(fc.by);
+            if(fc.where) $(`#${name}_filter_where`).val(fc.where);
+            if(fc.value!==undefined) $(`#${name}_filter_value`).val(fc.value);
+        }
+    });
+}
+function saveChannel(name){
+    const getVal=(id)=> $(`#${name}_${id}`).val();
+    const getNum=(id)=> { const v=getVal(id); return v===""||v===null? undefined : parseInt(v); };
+    const getFloat=(id)=> { const v=getVal(id); return v===""||v===null? undefined : parseFloat(v); };
+    const getBool=(id)=> { const v=getVal(id); return v===""||v===null? undefined : v==='true'; };
+    const data={};
+    const mp=getBool('make_predictions'); if(mp!==undefined) data.make_predictions=mp;
+    const fr=getBool('follow_raid'); if(fr!==undefined) data.follow_raid=fr;
+    const cd=getBool('claim_drops'); if(cd!==undefined) data.claim_drops=cd;
+    const chat=getVal('chat'); if(chat) data.chat=chat;
+    // bet
+    const bet={};
+    const strat=getVal('strategy'); if(strat) bet.strategy=strat;
+    const perc=getNum('percentage'); if(perc!==undefined) bet.percentage=perc;
+    const maxp=getNum('max_points'); if(maxp!==undefined) bet.max_points=maxp;
+    const stealth=getBool('stealth_mode'); if(stealth!==undefined) bet.stealth_mode=stealth;
+    const dmode=getVal('delay_mode'); if(dmode) bet.delay_mode=dmode;
+    const del=getFloat('delay'); if(del!==undefined) bet.delay=del;
+    const fby=getVal('filter_by'); const fwh=getVal('filter_where'); const fval=getVal('filter_value');
+    if(fby) bet.filter_condition={by:fby, where:fwh||'GTE', value: parseInt(fval||0)};
+    else if(Object.keys(bet).length>0) bet.filter_condition=null;
+    if(Object.keys(bet).length>0) data.bet=bet;
+    // include other defaults if empty -> send null to use global
+    $.ajax({url:`/api/config/streamer/${name}`, method:'PUT', contentType:'application/json', data: JSON.stringify(data), success:function(){
+        $(`#${name}-status`).text('Saved ✔').addClass('ok'); setTimeout(()=>$(`#${name}-status`).text(''),2000);
+        loadConfig();
+    }, error:function(xhr){ $(`#${name}-status`).text('Error '+xhr.responseText).addClass('err'); }});
+}
+function deleteChannel(name){
+    if(!confirm(`Delete per-channel config for ${name}? (will fallback to global)`)) return;
+    $.ajax({url:`/api/config/streamer/${name}`, method:'DELETE', success:function(){ loadConfig(); }});
+}
+function addStreamer(){
+    const name=$('#new-streamer-name').val().trim().toLowerCase();
+    if(!name) return alert('Enter username');
+    $.ajax({url:'/api/config/streamer', method:'POST', contentType:'application/json', data: JSON.stringify({username:name, settings:null}), success:function(){ $('#new-streamer-name').val(''); loadConfig(); }, error:function(xhr){ alert('Error: '+xhr.responseText); }});
+}
+function renderPriority(priority){
+    const c=$('#priority-editor'); c.empty();
+    const list = priority && priority.length>0 ? priority : (enumsCache? enumsCache.priorities.slice(0,3): ['STREAK','DROPS','ORDER']);
+    c.html(list.map((p,i)=>`<div class="priority-item" draggable="true" data-p="${p}" style="padding:6px 8px;border:1px solid var(--border);border-radius:6px;margin-bottom:4px;background:var(--bg);cursor:move"><i class="fa-solid fa-grip"></i> ${i+1}. ${p} <button class="btn-small" style="float:right" onclick="removePriority('${p}')"><i class="fa-solid fa-xmark"></i></button></div>`).join('') + `<div style="margin-top:8px"><select id="new-priority-val" class="input"></select> <button class="btn-small" onclick="addPriority()"><i class="fa-solid fa-plus"></i> Add</button></div>`);
+    if(enumsCache) $('#new-priority-val').html(enumsCache.priorities.map(v=>`<option value="${v}">${v}</option>`).join(''));
+    // drag handling
+    let dragSrc=null;
+    $('.priority-item').on('dragstart', function(e){ dragSrc=this; e.originalEvent.dataTransfer.effectAllowed='move'; });
+    $('.priority-item').on('dragover', function(e){ e.preventDefault(); });
+    $('.priority-item').on('drop', function(e){
+        e.preventDefault();
+        if(dragSrc && dragSrc!==this){
+            const src=$(dragSrc).data('p'), tgt=$(this).data('p');
+            const arr=$('#priority-editor .priority-item').map(function(){return $(this).data('p');}).get();
+            const sIdx=arr.indexOf(src), tIdx=arr.indexOf(tgt);
+            arr.splice(sIdx,1); arr.splice(tIdx,0,src);
+            renderPriority(arr);
+        }
+    });
+}
+function addPriority(){ const v=$('#new-priority-val').val(); if(!v) return; const arr=$('#priority-editor .priority-item').map(function(){return $(this).data('p');}).get(); if(arr.includes(v)) return; arr.push(v); renderPriority(arr); }
+function removePriority(p){ const arr=$('#priority-editor .priority-item').map(function(){return $(this).data('p');}).get().filter(x=>x!==p); renderPriority(arr); }
+function savePriority(){ const arr=$('#priority-editor .priority-item').map(function(){return $(this).data('p');}).get(); $.ajax({url:'/api/config', method:'PUT', contentType:'application/json', data: JSON.stringify({priority:arr}), success:function(){ alert('Priority saved'); }}); }
+
+$('.dropdown').click(()=> $('.dropdown').toggleClass('is-active'));
+
+// expose for inline handlers
+window.changeSortBy=changeSortBy; window.handleStreamerClick=handleStreamerClick; window.goHistoryPage=goHistoryPage; window.saveChannel=saveChannel; window.deleteChannel=deleteChannel; window.removePriority=removePriority; window.addPriority=addPriority;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,70 +1,111 @@
-html,
-body {
-    overflow-x: hidden;
-    overflow-y: auto;
+:root{
+  --bg:#1e1f2b; --panel:#2b2d3e; --panel-2:#343e59; --border:#3a3d52;
+  --text:#d7dae3; --muted:#8b8fa3; --accent:#f9826c; --accent-2:#ff9a8a;
+  --info:#7aa2f7; --warn:#e0af68; --error:#f7768e; --success:#9ece6a;
 }
-
-a {
-    text-decoration: none;
-}
-
-.tabs ul {
-    -webkit-flex-direction: column;
-    flex-direction: column;
-    flex-grow: 0px;
-}
-
-.tabs {
-    max-height: 500px;
-    overflow-y: auto;
-    direction: rtl;
-}
-
-.checkbox-label {
-    font-size: 20px;
-    padding-left: 15px;
-    font-weight: bold
-}
-
-::-webkit-scrollbar {
-    width: 20px;
-}
-
-::-webkit-scrollbar-track {
-    background-color: transparent;
-}
-
-::-webkit-scrollbar-thumb {
-    background-color: #d6dee1;
-}
-
-::-webkit-scrollbar-thumb {
-    background-color: #d6dee1;
-    border-radius: 20px;
-}
-
-::-webkit-scrollbar-thumb {
-    background-color: #d6dee1;
-    border-radius: 20px;
-    border: 6px solid transparent;
-    background-clip: content-box;
-}
-
-::-webkit-scrollbar-thumb:hover {
-    background-color: #a8bbbf;
-}
-
-#log-content {
-    text-align: left;
-    white-space: pre-wrap;
-    max-height: 400px;
-    padding: 0;
-}
-
-#auto-update-log {
-    display: none;
-    background-color: transparent;
-    font-size: 20px;
-    padding: 0;
-    border-radius: 5px;
-}
+*{box-sizing:border-box}
+html,body{margin:0;background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Inter,sans-serif;overflow-x:hidden}
+a{color:var(--accent);text-decoration:none}a:hover{color:var(--accent-2)}
+/* topbar */
+.topbar{display:flex;align-items:center;justify-content:space-between;padding:12px 18px;background:var(--panel);border-bottom:1px solid var(--border);flex-wrap:wrap;gap:12px}
+.topbar-left img{max-width:100%}
+.topbar-right{display:flex;align-items:center;gap:16px;flex-wrap:wrap}
+.header-stats{display:flex;gap:14px;flex-wrap:wrap;font-size:13px}
+.header-stats .stat{background:var(--bg);border:1px solid var(--border);padding:6px 10px;border-radius:20px;white-space:nowrap}
+.header-stats .stat i{color:var(--accent);margin-right:4px}
+.topbar-actions{display:flex;gap:8px;align-items:center}
+.btn-small{border:1px solid var(--border);background:var(--bg);color:var(--text);padding:6px 10px;border-radius:6px;cursor:pointer;font-size:13px}
+.btn-small:hover{border-color:var(--accent)}
+.btn-primary{background:var(--accent);color:#1e1f2b;border:none;padding:8px 14px;border-radius:6px;cursor:pointer;font-weight:600}
+.btn-primary:hover{background:var(--accent-2)}
+.toggle{font-size:13px;display:inline-flex;align-items:center;gap:6px;cursor:pointer}
+.toggle input{accent-color:var(--accent)}
+/* tabs */
+.tabs-nav{display:flex;gap:0;background:var(--panel);border-bottom:1px solid var(--border);padding:0 12px;overflow-x:auto}
+.tab-btn{padding:12px 18px;background:transparent;border:none;color:var(--muted);cursor:pointer;border-bottom:3px solid transparent;font-size:14px;white-space:nowrap}
+.tab-btn.active{color:var(--accent);border-bottom-color:var(--accent);font-weight:600}
+.tab-pane{display:none;padding:14px}
+.tab-pane.active{display:block}
+/* controls */
+.controls-bar{display:flex;flex-wrap:wrap;gap:10px;align-items:center;background:var(--panel);border:1px solid var(--border);border-radius:8px;padding:10px 12px;margin-bottom:14px}
+.control-group{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+.control-group.right{margin-left:auto}
+.input{background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:6px 10px;font-size:13px}
+.input:focus{outline:none;border-color:var(--accent)}
+.date-input{width:145px}
+.search-box{display:flex;align-items:center;gap:6px;background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:6px 10px}
+.search-box input{border:none;background:transparent;color:var(--text);outline:none;width:150px}
+.preset-group{display:flex;border:1px solid var(--border);border-radius:6px;overflow:hidden}
+.preset-btn{background:var(--bg);color:var(--text);border:none;padding:6px 10px;cursor:pointer;font-size:13px;border-right:1px solid var(--border)}
+.preset-btn:last-child{border-right:none}
+.preset-btn.active{background:var(--accent);color:#1e1f2b;font-weight:600}
+/* dropdown */
+.dropdown{position:relative}
+.dropdown .button{background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:6px 10px;cursor:pointer}
+.dropdown-menu{display:none;position:absolute;top:110%;left:0;background:var(--panel);border:1px solid var(--border);border-radius:6px;min-width:180px;z-index:20}
+.dropdown.is-active .dropdown-menu{display:block}
+.dropdown-item{display:block;padding:8px 12px;color:var(--text);font-size:13px}
+.dropdown-item:hover{background:var(--bg);color:var(--accent)}
+/* dashboard grid */
+.dashboard-grid{display:grid;grid-template-columns:280px 1fr;gap:14px;align-items:start}
+@media(max-width:900px){.dashboard-grid{grid-template-columns:1fr}}
+.streamers-panel{background:var(--panel);border:1px solid var(--border);border-radius:8px;overflow:hidden;max-height:75vh;display:flex;flex-direction:column}
+.panel-header{display:flex;justify-content:space-between;align-items:center;padding:10px 12px;border-bottom:1px solid var(--border);font-weight:600}
+.badge{background:var(--accent);color:#1e1f2b;padding:2px 8px;border-radius:20px;font-size:12px}
+.streamers-list{list-style:none;margin:0;padding:0;overflow-y:auto}
+.streamers-list li{border-bottom:1px solid var(--border)}
+.streamers-list li a{display:flex;justify-content:space-between;align-items:center;padding:9px 12px;color:var(--text);font-size:13px}
+.streamers-list li.is-active a{background:var(--bg);border-left:3px solid var(--accent)}
+.streamers-list li a:hover{background:var(--bg)}
+.streamers-list .points{color:var(--success);font-size:11px}
+.streamers-list .meta{color:var(--muted);font-size:11px}
+.dot{width:8px;height:8px;border-radius:50%;display:inline-block}
+.dot.online{background:var(--success)} .dot.offline{background:var(--muted)}
+.chart-panel{display:flex;flex-direction:column;gap:12px}
+.chart-header{display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:8px}
+.chart-header h2{margin:0;font-size:16px}
+.chart-stats{display:flex;gap:8px;flex-wrap:wrap;font-size:12px}
+.stat-chip{background:var(--panel);border:1px solid var(--border);padding:4px 8px;border-radius:14px}
+.box{background:var(--panel);border:1px solid var(--border);border-radius:8px;padding:10px}
+#chart{min-height:420px}
+.gain-breakdown{display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:8px}
+.gain-card{background:var(--panel);border:1px solid var(--border);border-radius:6px;padding:8px;font-size:12px}
+.gain-card b{color:var(--accent)}
+#log-box pre{max-height:400px;overflow:auto;white-space:pre-wrap;word-break:break-word;font-size:12px;margin:0}
+.box-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;font-weight:600}
+/* history */
+.history-controls{display:flex;flex-wrap:wrap;gap:10px;align-items:center;background:var(--panel);border:1px solid var(--border);border-radius:8px;padding:10px;margin-bottom:12px}
+.history-summary{display:flex;gap:10px;flex-wrap:wrap;margin-left:auto;font-size:13px}
+.table-wrapper{background:var(--panel);border:1px solid var(--border);border-radius:8px;overflow:auto}
+.history-table{width:100%;border-collapse:collapse;font-size:13px}
+.history-table th,.history-table td{padding:8px 10px;border-bottom:1px solid var(--border);text-align:left;white-space:nowrap}
+.history-table th{cursor:pointer;color:var(--muted);font-weight:600;background:var(--bg);position:sticky;top:0}
+.history-table tr:hover td{background:var(--bg)}
+.badge-type{padding:2px 6px;border-radius:10px;font-size:11px;font-weight:600}
+.badge-type.WIN{background:#36b535;color:#000} .badge-type.LOSE{background:#ff4545;color:#fff} .badge-type.BET_PLACED{background:#ffe045;color:#000} .badge-type.WATCH_STREAK{background:#45c1ff;color:#000}
+.pagination{display:flex;gap:6px;justify-content:center;margin-top:12px}
+.pagination button{padding:6px 10px}
+/* config */
+.config-layout{display:grid;gap:14px}
+.config-card{background:var(--panel);border:1px solid var(--border);border-radius:8px;padding:14px}
+.config-card h3{margin:0 0 10px 0;font-size:15px;display:flex;align-items:center;gap:8px}
+.config-card .subtitle{font-weight:400;color:var(--muted);font-size:12px;margin-left:8px}
+.card-header-row{display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:8px;margin-bottom:10px}
+.add-streamer-row{display:flex;gap:6px}
+.form-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;margin-bottom:10px}
+.form-group{display:flex;flex-direction:column;gap:4px}
+.form-group label{font-size:12px;color:var(--muted)}
+.form-group input,.form-group select{background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:6px 8px;font-size:13px}
+.help{color:var(--muted);font-size:12px}
+.save-status{font-size:13px;margin-left:10px}
+.save-status.ok{color:var(--success)} .save-status.err{color:var(--error)}
+.channel-row{border:1px solid var(--border);border-radius:6px;margin-bottom:8px;overflow:hidden}
+.channel-header{display:flex;justify-content:space-between;align-items:center;padding:8px 10px;background:var(--bg);cursor:pointer}
+.channel-header .name{font-weight:600}
+.channel-body{padding:10px;display:none}
+.channel-row.open .channel-body{display:block}
+.channel-actions{display:flex;gap:6px}
+.empty{color:var(--muted);text-align:center;padding:20px}
+::-webkit-scrollbar{width:8px;height:8px}
+::-webkit-scrollbar-thumb{background:#3a3d52;border-radius:4px}
+::-webkit-scrollbar-thumb:hover{background:var(--muted)}


### PR DESCRIPTION
Major UI upgrade as requested:

**Graph**
- Time presets 7D/30D/90D/All + aggregation raw/30Min/1H/6H/1D via /api/series
- Compare mode multi-streamer overlay, CSV export, zoom reset, gain breakdown
- New topbar stats (total points/gained/win-rate)

**Bet History**
- New endpoints /api/bets, /api/overview, /api/streamers/details parsing annotations
- Sortable/filterable table with pagination, type filters (WIN/LOSE/BET_PLACED/WATCH_STREAK)

**Config**
- Full /api/config CRUD (global + per-channel BetSettings including strategy/percentage/max_points/stealth/delay/filter_condition etc), priority drag-drop, persisted to analytics/<user>/config.json with live miner apply
- Enums endpoint for frontend validation

**Files**
- AnalyticsServer.py: new APIs + miner param
- charts.html/script.js/style.css: tabbed responsive layout
- TwitchChannelPointsMiner.py: pass miner to AnalyticsServer

Tested via Flask test_client (overview 55 streamers, bets 1957 rows, config CRUD, series agg).